### PR TITLE
Implement homepage layout and branding

### DIFF
--- a/frontend-en/src/components/ArticleCard.tsx
+++ b/frontend-en/src/components/ArticleCard.tsx
@@ -34,7 +34,7 @@ export default function ArticleCard({
         <div className="p-4 flex flex-col justify-between">
           <h3 className="text-lg font-semibold mb-2 line-clamp-2">{title}</h3>
           <p className="text-sm text-gray-600 mb-4 line-clamp-3">{excerpt}</p>
-          <span className="text-xs text-blue-600 font-medium hover:underline">
+          <span className="text-xs text-primary font-medium hover:underline">
             Read more →
           </span>
         </div>

--- a/frontend-en/src/components/CategoryMenu.tsx
+++ b/frontend-en/src/components/CategoryMenu.tsx
@@ -26,7 +26,7 @@ export default function CategoryMenu() {
         {categories.map((cat: Category) => (
           <li key={cat.slug}>
             <Link href={`/news/${cat.slug}`}>
-              <a className="block py-2 text-gray-700 hover:text-blue-600 capitalize whitespace-nowrap">
+              <a className="block py-2 text-gray-700 hover:text-primary capitalize whitespace-nowrap">
                 {cat.name}
               </a>
             </Link>

--- a/frontend-en/src/components/Navbar/Navbar.tsx
+++ b/frontend-en/src/components/Navbar/Navbar.tsx
@@ -35,7 +35,7 @@ export default function Navbar() {
           <div className="hidden md:flex space-x-8">
             {NAV_LINKS.map((link) => (
               <Link key={link.href} href={link.href}>
-                <a className="text-gray-700 hover:text-blue-600 font-medium">
+                <a className="text-gray-700 hover:text-primary font-medium">
                   {link.label}
                 </a>
               </Link>
@@ -67,7 +67,7 @@ export default function Navbar() {
             </button>
 
             <Link href="/auth/login">
-              <a className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+              <a className="px-4 py-2 bg-primary text-white rounded hover:bg-primary-dark">
                 Log in
               </a>
             </Link>

--- a/frontend-en/src/components/Navbar/SearchModal.tsx
+++ b/frontend-en/src/components/Navbar/SearchModal.tsx
@@ -51,12 +51,12 @@ export default function SearchModal({ onClose }: SearchModalProps) {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Type keywords..."
-            className="flex-grow border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="flex-grow border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
             autoFocus
           />
           <button
             type="submit"
-            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            className="px-4 py-2 bg-primary text-white rounded hover:bg-primary-dark"
           >
             Search
           </button>

--- a/frontend-en/src/components/NewsletterForm.tsx
+++ b/frontend-en/src/components/NewsletterForm.tsx
@@ -34,14 +34,14 @@ export default function NewsletterForm() {
         value={email}
         onChange={(e) => setEmail(e.target.value)}
         placeholder="Your email address"
-        className="w-full border border-gray-300 rounded px-3 py-2 mb-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="w-full border border-gray-300 rounded px-3 py-2 mb-2 focus:outline-none focus:ring-2 focus:ring-primary"
         required
       />
 
       <button
         type="submit"
         disabled={status === 'loading'}
-        className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 transition disabled:opacity-50"
+        className="w-full bg-primary text-white py-2 rounded hover:bg-primary-dark transition disabled:opacity-50"
       >
         {status === 'loading' ? 'Submitting…' : 'Subscribe'}
       </button>

--- a/frontend-en/src/components/SideBanners.tsx
+++ b/frontend-en/src/components/SideBanners.tsx
@@ -5,7 +5,7 @@ export default function SideBanners() {
     <aside className="fixed top-1/3 right-4 flex flex-col space-y-6 z-40">
       {/* Banner Newsletter */}
       <Link href="/subscribe">
-        <a className="block w-40 p-4 bg-blue-600 text-white rounded-l-lg shadow hover:bg-blue-700 transition">
+        <a className="block w-40 p-4 bg-primary text-white rounded-l-lg shadow hover:bg-primary-dark transition">
           <h3 className="font-bold mb-1">Newsletter</h3>
           <p className="text-sm">Join our weekly insights</p>
         </a>

--- a/frontend-en/src/pages/account/index.tsx
+++ b/frontend-en/src/pages/account/index.tsx
@@ -112,7 +112,7 @@ export default function AccountPage() {
           <button
             type="submit"
             disabled={profileLoading}
-            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+            className="px-4 py-2 bg-primary text-white rounded hover:bg-primary-dark disabled:opacity-50"
           >
             {profileLoading ? 'Saving…' : 'Save Changes'}
           </button>
@@ -153,7 +153,7 @@ export default function AccountPage() {
           <div>
             <p>You do not have an active subscription.</p>
             <Link href="/checkout">
-              <a className="inline-block mt-2 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+              <a className="inline-block mt-2 px-4 py-2 bg-primary text-white rounded hover:bg-primary-dark">
                 Subscribe Now
               </a>
             </Link>

--- a/frontend-en/src/pages/account/subscription.tsx
+++ b/frontend-en/src/pages/account/subscription.tsx
@@ -94,7 +94,7 @@ export default function SubscriptionPage() {
         <button
           type="submit"
           disabled={creatingSession}
-          className="w-full px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+          className="w-full px-4 py-2 bg-primary text-white rounded hover:bg-primary-dark disabled:opacity-50"
         >
           {subscription ? 'Change Plan' : 'Subscribe Now'}
         </button>

--- a/frontend-en/src/pages/auth/forgot-password.tsx
+++ b/frontend-en/src/pages/auth/forgot-password.tsx
@@ -45,7 +45,7 @@ export default function ForgotPasswordPage() {
                   <label className="block text-sm font-medium mb-1">Email</label>
                   <input
                     type="email"
-                    className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
                     required
@@ -54,7 +54,7 @@ export default function ForgotPasswordPage() {
                 <button
                   type="submit"
                   disabled={status === 'loading'}
-                  className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+                  className="w-full bg-primary text-white py-2 rounded hover:bg-primary-dark disabled:opacity-50"
                 >
                   {status === 'loading' ? 'Sending…' : 'Send Reset Link'}
                 </button>
@@ -64,7 +64,7 @@ export default function ForgotPasswordPage() {
 
           <p className="mt-6 text-center text-sm">
             <Link href="/auth/login">
-              <a className="text-blue-600 hover:underline">Back to login</a>
+              <a className="text-primary hover:underline">Back to login</a>
             </Link>
           </p>
         </div>

--- a/frontend-en/src/pages/auth/login.tsx
+++ b/frontend-en/src/pages/auth/login.tsx
@@ -33,7 +33,7 @@ export default function LoginPage() {
             <label className="block text-sm font-medium mb-1">Email</label>
             <input
               type="email"
-              className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
@@ -43,7 +43,7 @@ export default function LoginPage() {
             <label className="block text-sm font-medium mb-1">Password</label>
             <input
               type="password"
-              className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
@@ -52,7 +52,7 @@ export default function LoginPage() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+            className="w-full bg-primary text-white py-2 rounded hover:bg-primary-dark disabled:opacity-50"
           >
             {loading ? 'Logging in…' : 'Log In'}
           </button>
@@ -60,7 +60,7 @@ export default function LoginPage() {
         <p className="mt-4 text-center text-sm">
           Don’t have an account?{' '}
           <Link href="/auth/register">
-            <a className="text-blue-600 hover:underline">Register</a>
+            <a className="text-primary hover:underline">Register</a>
           </Link>
         </p>
       </div>

--- a/frontend-en/src/pages/auth/register.tsx
+++ b/frontend-en/src/pages/auth/register.tsx
@@ -46,7 +46,7 @@ export default function RegisterPage() {
             <label className="block text-sm font-medium mb-1">Name</label>
             <input
               type="text"
-              className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
               value={name}
               onChange={(e) => setName(e.target.value)}
               required
@@ -56,7 +56,7 @@ export default function RegisterPage() {
             <label className="block text-sm font-medium mb-1">Email</label>
             <input
               type="email"
-              className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
@@ -66,7 +66,7 @@ export default function RegisterPage() {
             <label className="block text-sm font-medium mb-1">Password</label>
             <input
               type="password"
-              className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
@@ -78,7 +78,7 @@ export default function RegisterPage() {
             </label>
             <input
               type="password"
-              className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
               value={confirm}
               onChange={(e) => setConfirm(e.target.value)}
               required
@@ -87,7 +87,7 @@ export default function RegisterPage() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+            className="w-full bg-primary text-white py-2 rounded hover:bg-primary-dark disabled:opacity-50"
           >
             {loading ? 'Registering…' : 'Register'}
           </button>
@@ -95,7 +95,7 @@ export default function RegisterPage() {
         <p className="mt-4 text-center text-sm">
           Already have an account?{' '}
           <Link href="/auth/login">
-            <a className="text-blue-600 hover:underline">Log In</a>
+            <a className="text-primary hover:underline">Log In</a>
           </Link>
         </p>
       </div>

--- a/frontend-en/src/pages/auth/reset-password.tsx
+++ b/frontend-en/src/pages/auth/reset-password.tsx
@@ -60,7 +60,7 @@ export default function ResetPasswordPage() {
             <>
               <p className="text-green-600 mb-4">{message}</p>
               <Link href="/auth/login">
-                <a className="block text-center text-blue-600 hover:underline">
+                <a className="block text-center text-primary hover:underline">
                   Go to Login
                 </a>
               </Link>
@@ -73,7 +73,7 @@ export default function ResetPasswordPage() {
                   <label className="block text-sm font-medium mb-1">New Password</label>
                   <input
                     type="password"
-                    className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                     required
@@ -86,7 +86,7 @@ export default function ResetPasswordPage() {
                   </label>
                   <input
                     type="password"
-                    className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
                     value={confirm}
                     onChange={(e) => setConfirm(e.target.value)}
                     required
@@ -96,7 +96,7 @@ export default function ResetPasswordPage() {
                 <button
                   type="submit"
                   disabled={status === 'submitting'}
-                  className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+                  className="w-full bg-primary text-white py-2 rounded hover:bg-primary-dark disabled:opacity-50"
                 >
                   {status === 'submitting' ? 'Submitting…' : 'Reset Password'}
                 </button>
@@ -106,7 +106,7 @@ export default function ResetPasswordPage() {
 
           <p className="mt-6 text-center text-sm">
             <Link href="/auth/login">
-              <a className="text-blue-600 hover:underline">Back to login</a>
+              <a className="text-primary hover:underline">Back to login</a>
             </Link>
           </p>
         </div>

--- a/frontend-en/src/pages/index.tsx
+++ b/frontend-en/src/pages/index.tsx
@@ -1,11 +1,7 @@
 // src/pages/index.tsx
 import { useState, useEffect } from 'react';
-import Navbar from '../components/Navbar/Navbar';
-import CryptoTicker from '../components/CryptoTicker';
 import useGeoCategories, { Category } from '../hooks/useGeoCategories';
 import CategoryCarousel, { Article } from '../components/CategoryCarousel/CategoryCarousel';
-import SideBanners from '../components/SideBanners';
-import Footer from '../components/Footer';
 import apiClient from '../utils/apiClient';
 
 export default function HomePage() {
@@ -37,40 +33,26 @@ export default function HomePage() {
   }, [categories, loading, error]);
 
   if (loading) {
-    return (
-      <>
-        <Navbar />
-        <div className="pt-24 text-center">Loading categories…</div>
-      </>
-    );
+    return <div className="pt-24 text-center">Loading categories…</div>;
   }
 
   if (error) {
     return (
-      <>
-        <Navbar />
-        <div className="pt-24 text-center text-red-600">Error loading categories: {error}</div>
-      </>
+      <div className="pt-24 text-center text-red-600">
+        Error loading categories: {error}
+      </div>
     );
   }
 
   return (
-    <>
-      <Navbar />
-      <CryptoTicker />
-
-      <main className="max-w-7xl mx-auto px-4 pt-8 pb-16">
-        {categories.map((cat: Category) => (
-          <CategoryCarousel
-            key={cat.slug}
-            country={cat.name}
-            articles={articlesMap[cat.slug] || []}
-          />
-        ))}
-      </main>
-
-      <SideBanners />
-      <Footer />
-    </>
+    <main className="max-w-7xl mx-auto px-4 pt-8 pb-16">
+      {categories.map((cat: Category) => (
+        <CategoryCarousel
+          key={cat.slug}
+          country={cat.name}
+          articles={articlesMap[cat.slug] || []}
+        />
+      ))}
+    </main>
   );
 }

--- a/frontend-en/src/styles/_banners.css
+++ b/frontend-en/src/styles/_banners.css
@@ -6,7 +6,7 @@
   }
   /* Banner de newsletter */
   .banner-newsletter {
-    @apply block w-40 p-4 bg-blue-600 text-white rounded-l-lg shadow hover:bg-blue-700 transition;
+    @apply block w-40 p-4 bg-primary text-white rounded-l-lg shadow hover:bg-primary-dark transition;
   }
   /* Banner de subscrição */
   .banner-subscription {

--- a/frontend-en/src/styles/_navbar.css
+++ b/frontend-en/src/styles/_navbar.css
@@ -10,7 +10,7 @@
     @apply hidden md:flex space-x-8;
   }
   .nav-link {
-    @apply text-gray-700 hover:text-blue-600 font-medium;
+    @apply text-gray-700 hover:text-primary font-medium;
   }
   .nav-actions {
     @apply flex items-center space-x-4;
@@ -19,7 +19,7 @@
     @apply p-2 rounded hover:bg-gray-100;
   }
   .login-button {
-    @apply px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700;
+    @apply px-4 py-2 bg-primary text-white rounded hover:bg-primary-dark;
   }
   .spacer {
     @apply h-16;

--- a/frontend-en/src/styles/globals.css
+++ b/frontend-en/src/styles/globals.css
@@ -14,7 +14,7 @@ body {
 
 /* 3. Link defaults */
 a {
-  @apply text-blue-600 hover:text-blue-700;
+  @apply text-primary hover:text-primary-dark;
 }
 
 /* 4. Hide focus outlines except when keyboard-navigating */

--- a/frontend-en/src/styles/tailwind.config.js
+++ b/frontend-en/src/styles/tailwind.config.js
@@ -11,8 +11,9 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        // exemplo, puxando da sua logo
-        primary: '#1A73E8',
+        // cores baseadas na logo
+        primary: '#5691BB',
+        'primary-dark': '#4A7FA3',
         secondary: '#34A853',
       },
       // se quiser animações/globals extras:


### PR DESCRIPTION
## Summary
- apply brand color from logo across navbar, banners, buttons and links
- simplify homepage by relying on global layout
- add custom `primary` color to Tailwind config

## Testing
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6846ccb017e0832fb4bd91423be7b0ba