### PR TITLE
Implement search and login dropdowns in navbar

### DIFF
--- a/frontend-en/next-env.d.ts
+++ b/frontend-en/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/frontend-en/src/components/Navbar/LoginDropdown.tsx
+++ b/frontend-en/src/components/Navbar/LoginDropdown.tsx
@@ -1,0 +1,62 @@
+import { FormEvent, useState, useEffect, useRef } from 'react';
+import useAuth from '../../hooks/useAuth';
+
+interface LoginDropdownProps {
+  onClose: () => void;
+}
+
+export default function LoginDropdown({ onClose }: LoginDropdownProps) {
+  const { login, loading, error } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [onClose]);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    await login(email.trim(), password);
+  }
+
+  return (
+    <div
+      ref={ref}
+      className="absolute right-0 top-full mt-2 bg-white p-4 shadow rounded w-72 z-40"
+    >
+      <form onSubmit={handleSubmit} className="space-y-2">
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+          className="w-full border border-gray-300 rounded px-3 py-1 focus:outline-none focus:ring-2 focus:ring-primary"
+          required
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="w-full border border-gray-300 rounded px-3 py-1 focus:outline-none focus:ring-2 focus:ring-primary"
+          required
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-primary text-white py-1 rounded hover:bg-primary-dark disabled:opacity-50"
+        >
+          {loading ? 'Logging in…' : 'Log In'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend-en/src/components/Navbar/Navbar.tsx
+++ b/frontend-en/src/components/Navbar/Navbar.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import SearchModal from './SearchModal';
+import SearchDropdown from './SearchDropdown';
+import LoginDropdown from './LoginDropdown';
 
 const NAV_LINKS = [
   { label: 'News', href: '/news/global' },
@@ -13,11 +14,12 @@ const NAV_LINKS = [
 
 export default function Navbar() {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [isLoginOpen, setIsLoginOpen] = useState(false);
 
   return (
     <>
       <nav className="fixed top-0 left-0 right-0 z-50 bg-white shadow">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
           {/* Logo */}
           <Link href="/">
             <a className="flex-shrink-0">
@@ -45,7 +47,10 @@ export default function Navbar() {
           {/* Search + Login */}
           <div className="flex items-center space-x-4">
             <button
-              onClick={() => setIsSearchOpen(true)}
+              onClick={() => {
+                setIsSearchOpen((prev) => !prev);
+                setIsLoginOpen(false);
+              }}
               aria-label="Search articles"
               className="p-2 rounded hover:bg-gray-100"
             >
@@ -66,20 +71,28 @@ export default function Navbar() {
               </svg>
             </button>
 
-            <Link href="/auth/login">
-              <a className="px-4 py-2 bg-primary text-white rounded hover:bg-primary-dark">
-                Log in
-              </a>
-            </Link>
+            <button
+              onClick={() => {
+                setIsLoginOpen((prev) => !prev);
+                setIsSearchOpen(false);
+              }}
+              className="px-4 py-2 bg-primary text-white rounded hover:bg-primary-dark"
+            >
+              Log in
+            </button>
           </div>
         </div>
+
+        {isSearchOpen && (
+          <SearchDropdown onClose={() => setIsSearchOpen(false)} />
+        )}
+        {isLoginOpen && (
+          <LoginDropdown onClose={() => setIsLoginOpen(false)} />
+        )}
       </nav>
 
       {/* espaço para não sobrepor o conteúdo */}
       <div className="h-16" />
-
-      {/* Search Modal */}
-      {isSearchOpen && <SearchModal onClose={() => setIsSearchOpen(false)} />}
     </>
   );
 }

--- a/frontend-en/src/components/Navbar/SearchDropdown.tsx
+++ b/frontend-en/src/components/Navbar/SearchDropdown.tsx
@@ -1,0 +1,51 @@
+import { FormEvent, useState, useEffect, useRef } from 'react';
+
+interface SearchDropdownProps {
+  onClose: () => void;
+}
+
+export default function SearchDropdown({ onClose }: SearchDropdownProps) {
+  const [query, setQuery] = useState('');
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [onClose]);
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (query.trim()) {
+      window.location.href = `/search?query=${encodeURIComponent(query.trim())}`;
+    }
+  }
+
+  return (
+    <div
+      ref={ref}
+      className="absolute right-24 top-full mt-2 bg-white p-4 shadow rounded w-64 z-40"
+    >
+      <form onSubmit={handleSubmit} className="flex space-x-2">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Type keywords..."
+          className="flex-grow border border-gray-300 rounded px-3 py-1 focus:outline-none focus:ring-2 focus:ring-primary"
+          autoFocus
+        />
+        <button
+          type="submit"
+          className="px-3 py-1 bg-primary text-white rounded hover:bg-primary-dark"
+        >
+          Search
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add dropdown components for search and login
- include Next.js generated type definitions
- update Navbar to open search and login forms directly from the bar

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6846d512fe2c832f95c99bf1d0bfb964