### PR TITLE
Add responsive hamburger menu

### DIFF
--- a/frontend-en/src/components/Navbar/Navbar.tsx
+++ b/frontend-en/src/components/Navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import SearchDropdown from './SearchDropdown';
@@ -15,10 +15,22 @@ const NAV_LINKS = [
 export default function Navbar() {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isLoginOpen, setIsLoginOpen] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const navRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (navRef.current && !navRef.current.contains(event.target as Node)) {
+        setIsMenuOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
 
   return (
     <>
-      <nav className="fixed top-0 left-0 right-0 z-50 bg-white shadow">
+      <nav ref={navRef} className="fixed top-0 left-0 right-0 z-50 bg-white shadow">
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
           {/* Logo */}
           <Link href="/">
@@ -48,8 +60,30 @@ export default function Navbar() {
           <div className="flex items-center space-x-4">
             <button
               onClick={() => {
+                setIsMenuOpen((prev) => !prev);
+                setIsSearchOpen(false);
+                setIsLoginOpen(false);
+              }}
+              aria-label="Toggle menu"
+              className="p-2 rounded hover:bg-gray-100 md:hidden"
+            >
+              {/* hamburger icon */}
+              <svg
+                className="h-6 w-6 text-gray-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            </button>
+
+            <button
+              onClick={() => {
                 setIsSearchOpen((prev) => !prev);
                 setIsLoginOpen(false);
+                setIsMenuOpen(false);
               }}
               aria-label="Search articles"
               className="p-2 rounded hover:bg-gray-100"
@@ -75,6 +109,7 @@ export default function Navbar() {
               onClick={() => {
                 setIsLoginOpen((prev) => !prev);
                 setIsSearchOpen(false);
+                setIsMenuOpen(false);
               }}
               className="px-4 py-2 bg-primary text-white rounded hover:bg-primary-dark"
             >
@@ -83,6 +118,21 @@ export default function Navbar() {
           </div>
         </div>
 
+        {isMenuOpen && (
+          <div className="md:hidden absolute top-full left-0 right-0 bg-white shadow border-t z-40">
+            {NAV_LINKS.map((link) => (
+              <Link key={link.href} href={link.href}>
+                <a
+                  className="block px-4 py-2 text-gray-700 hover:bg-gray-100"
+                  onClick={() => setIsMenuOpen(false)}
+                >
+                  {link.label}
+                </a>
+              </Link>
+            ))}
+          </div>
+        )}
+        
         {isSearchOpen && (
           <SearchDropdown onClose={() => setIsSearchOpen(false)} />
         )}


### PR DESCRIPTION
## Summary
- make Navbar responsive with a hamburger menu on small screens

## Testing
- `npm --prefix frontend-en run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684709938008832fb0fcc1d7606e0aea