### PR TITLE
Fix subscription banner and page

### DIFF
--- a/frontend-en/src/components/SideBanners.tsx
+++ b/frontend-en/src/components/SideBanners.tsx
@@ -44,10 +44,10 @@ export default function SideBanners() {
       </div>
 
       {/* Banner Subscription */}
-      <Link href="/checkout">
+      <Link href="/auth/register">
         <a className="block w-40 p-4 bg-green-600 text-white rounded-l-lg shadow hover:text-gray-300 transition">
           <h3 className="font-bold mb-1">Subscription</h3>
-          <p className="text-sm">Consiga análises antecipadas dos nossos especialistas</p>
+          <p className="text-sm">Get early analyses from our experts</p>
         </a>
       </Link>
     </aside>

--- a/frontend-en/src/pages/account/subscription.tsx
+++ b/frontend-en/src/pages/account/subscription.tsx
@@ -34,10 +34,10 @@ export default function SubscriptionPage() {
     }
   }, [authLoading]);
 
-  // Redirect non-logged-in users
+  // Redirect non-logged-in users to registration
   useEffect(() => {
     if (!authLoading && !user) {
-      router.replace('/auth/login');
+      router.replace('/auth/register');
     }
   }, [user, authLoading, router]);
 

--- a/frontend-en/src/pages/auth/forgot-password.tsx
+++ b/frontend-en/src/pages/auth/forgot-password.tsx
@@ -63,9 +63,7 @@ export default function ForgotPasswordPage() {
           )}
 
           <p className="mt-6 text-center text-sm">
-            <Link href="/auth/login">
-              <a className="text-primary hover:underline">Back to login</a>
-            </Link>
+            Use the login button in the navigation bar.
           </p>
         </div>
       </div>

--- a/frontend-en/src/pages/auth/login.tsx
+++ b/frontend-en/src/pages/auth/login.tsx
@@ -1,69 +1,11 @@
-// src/pages/auth/login.tsx
-import { FormEvent, useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useRouter } from 'next/router';
-import Link from 'next/link';
-import useAuth from '../../hooks/useAuth';
 
 export default function LoginPage() {
   const router = useRouter();
-  const { user, login, loading, error } = useAuth();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-
-  // Se já estiver logado, redireciona ao dashboard
   useEffect(() => {
-    if (user) {
-      router.replace('/account');
-    }
-  }, [user, router]);
-
-  async function handleSubmit(e: FormEvent) {
-    e.preventDefault();
-    await login(email.trim(), password);
-    // Se o login foi bem-sucedido, o efeito acima fará o redirect
-  }
-
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <div className="w-full max-w-md bg-white p-8 rounded shadow">
-        <h1 className="text-2xl font-semibold mb-6 text-center">Log In</h1>
-        {error && <p className="text-red-600 mb-4">{error}</p>}
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium mb-1">Email</label>
-            <input
-              type="email"
-              className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Password</label>
-            <input
-              type="password"
-              className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-            />
-          </div>
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full bg-primary text-white py-2 rounded hover:bg-primary-dark disabled:opacity-50"
-          >
-            {loading ? 'Logging in…' : 'Log In'}
-          </button>
-        </form>
-        <p className="mt-4 text-center text-sm">
-          Don’t have an account?{' '}
-          <Link href="/auth/register">
-            <a className="text-primary hover:underline">Register</a>
-          </Link>
-        </p>
-      </div>
-    </div>
-  );
+    router.replace('/');
+  }, [router]);
+  return null;
 }
+

--- a/frontend-en/src/pages/auth/register.tsx
+++ b/frontend-en/src/pages/auth/register.tsx
@@ -93,10 +93,7 @@ export default function RegisterPage() {
           </button>
         </form>
         <p className="mt-4 text-center text-sm">
-          Already have an account?{' '}
-          <Link href="/auth/login">
-            <a className="text-primary hover:underline">Log In</a>
-          </Link>
+          Already have an account? Use the login button in the navigation bar.
         </p>
       </div>
     </div>

--- a/frontend-en/src/pages/auth/reset-password.tsx
+++ b/frontend-en/src/pages/auth/reset-password.tsx
@@ -59,11 +59,7 @@ export default function ResetPasswordPage() {
           {status === 'success' ? (
             <>
               <p className="text-green-600 mb-4">{message}</p>
-              <Link href="/auth/login">
-                <a className="block text-center text-primary hover:underline">
-                  Go to Login
-                </a>
-              </Link>
+              <p className="block text-center text-primary">Use the login button in the navigation bar.</p>
             </>
           ) : (
             <>
@@ -105,9 +101,7 @@ export default function ResetPasswordPage() {
           )}
 
           <p className="mt-6 text-center text-sm">
-            <Link href="/auth/login">
-              <a className="text-primary hover:underline">Back to login</a>
-            </Link>
+            Use the login button in the navigation bar.
           </p>
         </div>
       </div>

--- a/frontend-en/src/pages/checkout.tsx
+++ b/frontend-en/src/pages/checkout.tsx
@@ -1,22 +1,2 @@
-// src/pages/checkout.tsx
-import { useEffect } from 'react';
-import { useRouter } from 'next/router';
-import useAuth from '../hooks/useAuth';
+export { default } from './auth/register';
 
-export default function CheckoutPage() {
-  const { user, loading } = useAuth();
-  const router = useRouter();
-
-  // Se não estiver logado, envia para login; se já logado, vai para gestão de planos
-  useEffect(() => {
-    if (!loading) {
-      if (!user) {
-        router.replace('/auth/login?next=/checkout');
-      } else {
-        router.replace('/account/subscription');
-      }
-    }
-  }, [user, loading, router]);
-
-  return <div className="pt-24 text-center">Redirecting…</div>;
-}


### PR DESCRIPTION
## Summary
- update subscription side banner text to English and link to registration page
- remove standalone login page and redirect to home
- make checkout point to register page and allow subscription without login
- update pages referencing login page
- redirect unauthenticated users from subscription page to signup

## Testing
- `npm install` *(fails: next lint expects interactive prompts)*
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684710d75df0832f9c97ca47e9d9d1c8