### PR TITLE
Add subscription CTA and signup plans

### DIFF
--- a/frontend-en/src/components/SideBanners.tsx
+++ b/frontend-en/src/components/SideBanners.tsx
@@ -48,6 +48,9 @@ export default function SideBanners() {
         <a className="block w-40 p-4 bg-green-600 text-white rounded-l-lg shadow hover:text-gray-300 transition">
           <h3 className="font-bold mb-1">Subscription</h3>
           <p className="text-sm">Get early analyses from our experts</p>
+          <span className="mt-2 inline-block px-3 py-1 bg-white text-green-700 rounded text-sm font-semibold">
+            Subscribe Now
+          </span>
         </a>
       </Link>
     </aside>

--- a/frontend-en/src/pages/auth/register.tsx
+++ b/frontend-en/src/pages/auth/register.tsx
@@ -1,8 +1,8 @@
 // src/pages/auth/register.tsx
 import { FormEvent, useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import Link from 'next/link';
 import useAuth from '../../hooks/useAuth';
+import { getPlans, createCheckoutSession, Plan } from '../../services/paymentService';
 
 export default function RegisterPage() {
   const router = useRouter();
@@ -11,6 +11,8 @@ export default function RegisterPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [selectedPlan, setSelectedPlan] = useState('');
   const [validationError, setValidationError] = useState<string | null>(null);
 
   // Se já estiver logado, vai pro dashboard
@@ -20,6 +22,12 @@ export default function RegisterPage() {
     }
   }, [user, router]);
 
+  useEffect(() => {
+    getPlans().then(setPlans).catch(() => {
+      setValidationError('Failed to load plans.');
+    });
+  }, []);
+
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     // Validação básica de senha
@@ -27,9 +35,18 @@ export default function RegisterPage() {
       setValidationError('Passwords do not match.');
       return;
     }
+    if (!selectedPlan) {
+      setValidationError('Please select a plan.');
+      return;
+    }
     setValidationError(null);
     await register(name.trim(), email.trim(), password);
-    // Após sucesso, o efeito acima faz o redirect
+    try {
+      const session = await createCheckoutSession(selectedPlan);
+      window.location.href = session.checkoutUrl;
+    } catch {
+      setValidationError('Could not start checkout.');
+    }
   }
 
   return (
@@ -76,25 +93,49 @@ export default function RegisterPage() {
             <label className="block text-sm font-medium mb-1">
               Confirm Password
             </label>
-            <input
-              type="password"
-              className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
-              value={confirm}
-              onChange={(e) => setConfirm(e.target.value)}
-              required
-            />
-          </div>
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full bg-primary text-white py-2 rounded hover:bg-primary-dark disabled:opacity-50"
-          >
-            {loading ? 'Registering…' : 'Register'}
-          </button>
-        </form>
-        <p className="mt-4 text-center text-sm">
-          Already have an account? Use the login button in the navigation bar.
-        </p>
+          <input
+            type="password"
+            className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <p className="text-sm font-medium mb-2">Choose a plan</p>
+          {plans.map((plan) => (
+            <label
+              key={plan.id}
+              className="flex items-start border rounded-lg p-2 mb-2"
+            >
+              <input
+                type="radio"
+                name="plan"
+                value={plan.id}
+                checked={selectedPlan === plan.id}
+                onChange={() => setSelectedPlan(plan.id)}
+                className="mt-1 mr-2"
+              />
+              <span>
+                <span className="font-semibold">{plan.name}</span>
+                <span className="block text-gray-700 text-sm">
+                  ${plan.price.toFixed(2)} / {plan.interval}
+                </span>
+                <span className="block text-xs text-gray-500">
+                  {plan.description}
+                </span>
+              </span>
+            </label>
+          ))}
+        </div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-primary text-white py-2 rounded hover:bg-primary-dark disabled:opacity-50"
+        >
+          {loading ? 'Registering…' : 'Register'}
+        </button>
+      </form>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show CTA button in the subscription banner
- merge registration with subscription options and remove login note

## Testing
- `npm run build` *(fails: compiled with warnings)*
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_684719bb44dc832fbbca0221aecc3493