### PR TITLE
Update login dropdown position and text

### DIFF
--- a/frontend-en/src/components/Footer.tsx
+++ b/frontend-en/src/components/Footer.tsx
@@ -5,7 +5,7 @@ export default function Footer() {
     <footer className="bg-gray-800 text-gray-300 py-8 mt-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-3 text-center">
         <p className="text-sm md:max-w-xl mx-auto">
-          Disclaimer: This site provides information for educational purposes only. Not financial advice.
+          This site provides information for educational purposes only. Not financial advice.
         </p>
         <div className="flex justify-center space-x-6">
           <Link href="/about">

--- a/frontend-en/src/components/Navbar/LoginDropdown.tsx
+++ b/frontend-en/src/components/Navbar/LoginDropdown.tsx
@@ -29,7 +29,7 @@ export default function LoginDropdown({ onClose }: LoginDropdownProps) {
   return (
     <div
       ref={ref}
-      className="absolute right-0 top-full mt-2 bg-white p-4 shadow rounded w-72 z-40"
+      className="fixed top-0 right-0 h-full w-80 bg-white p-4 shadow-lg z-40"
     >
       <form onSubmit={handleSubmit} className="space-y-2">
         {error && <p className="text-red-600 text-sm">{error}</p>}

--- a/frontend-en/src/components/Navbar/Navbar.tsx
+++ b/frontend-en/src/components/Navbar/Navbar.tsx
@@ -31,7 +31,9 @@ export default function Navbar() {
   return (
     <>
       <nav ref={navRef} className="fixed top-0 left-0 right-0 z-50 bg-white shadow">
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+        <div
+          className={`relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between transition-all ${isLoginOpen ? 'mr-80' : ''}`}
+        >
           {/* Logo */}
           <Link href="/">
             <a className="flex-shrink-0">

--- a/frontend-en/src/components/SideBanners.tsx
+++ b/frontend-en/src/components/SideBanners.tsx
@@ -47,7 +47,7 @@ export default function SideBanners() {
       <Link href="/auth/register">
         <a className="block w-40 p-4 bg-green-600 text-white rounded-l-lg shadow hover:text-gray-300 transition">
           <h3 className="font-bold mb-1">Subscription</h3>
-          <p className="text-sm">Get early analyses from our experts</p>
+          <p className="text-sm">Get early price analysis from our experts</p>
           <span className="mt-2 inline-block px-3 py-1 bg-white text-green-700 rounded text-sm font-semibold">
             Subscribe Now
           </span>


### PR DESCRIPTION
## Summary
- open login dropdown as a side panel pushing navigation
- tweak subscription banner text
- simplify footer disclaimer

## Testing
- `npm run lint` *(fails: asks to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68471d2cdfb8832f83f1af37e3f9cad2