### PR TITLE
Fix ticker API path and category loading

### DIFF
--- a/frontend-en/src/components/CryptoTicker.tsx
+++ b/frontend-en/src/components/CryptoTicker.tsx
@@ -12,7 +12,8 @@ export default function CryptoTicker() {
   useEffect(() => {
     async function fetchPrices() {
       try {
-        const resp = await apiClient.get<CryptoPrice[]>('/api/crypto/prices');
+        // ajustado para rota correta exposta no backend
+        const resp = await apiClient.get<CryptoPrice[]>('/api/crypto/ticker');
         setPrices(resp.data);
       } catch (err) {
         console.error('Failed to load crypto prices', err);

--- a/frontend-en/src/contexts/CryptoContext.tsx
+++ b/frontend-en/src/contexts/CryptoContext.tsx
@@ -30,7 +30,8 @@ export function CryptoProvider({ children }: { children: ReactNode }) {
       setLoading(true);
       setError(null);
       try {
-        const resp = await apiClient.get<CryptoPrice[]>('/api/crypto/prices');
+        // rota corrigida para o ticker de preços
+        const resp = await apiClient.get<CryptoPrice[]>('/api/crypto/ticker');
         setPrices(resp.data);
       } catch (err: any) {
         console.error('Crypto fetch error', err);

--- a/frontend-en/src/hooks/useGeoCategories.ts
+++ b/frontend-en/src/hooks/useGeoCategories.ts
@@ -25,39 +25,12 @@ export default function useGeoCategories(): GeoCategoriesHook {
     async function load() {
       setLoading(true);
       try {
-        // 1) Pega a localização do usuário
-        const geoRes = await apiClient.get<{ country: string }>('/api/geo');
-        const userCountry = geoRes.data.country.toLowerCase();
-
-        // 2) Busca todas as categorias (países) disponíveis
-        const catRes = await apiClient.get<Category[]>('/api/news/categories');
+        // Busca todas as categorias disponíveis
+        const catRes = await apiClient.get<Category[]>('/api/categories');
         const fetched = catRes.data;
 
-        // 3) Reordena trazendo o país do usuário (ou "global") para primeiro
-        const ordered = [...fetched];
-        const matchIdx = ordered.findIndex(
-          (c) =>
-            c.slug.toLowerCase() === userCountry ||
-            c.name.toLowerCase() === userCountry
-        );
-
-        if (matchIdx > 0) {
-          const [matched] = ordered.splice(matchIdx, 1);
-          ordered.unshift(matched);
-        } else {
-          // Se não achou, traz "global" como fallback
-          const globalIdx = ordered.findIndex(
-            (c) =>
-              c.slug.toLowerCase() === 'global' ||
-              c.name.toLowerCase() === 'global'
-          );
-          if (globalIdx > 0) {
-            const [globalCat] = ordered.splice(globalIdx, 1);
-            ordered.unshift(globalCat);
-          }
-        }
-
-        setCategories(ordered);
+        // Sem geolocalização, apenas usa a ordem vinda da API
+        setCategories(fetched);
       } catch (err: any) {
         console.error('useGeoCategories error:', err);
         setError('Failed to load categories');


### PR DESCRIPTION
## Summary
- fetch crypto prices using `/api/crypto/ticker`
- fix crypto context to use the same ticker route
- load categories from `/api/categories` without geolocation

## Testing
- `npm install` within `frontend-en`
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_684729776998832f96bdaac5155c8afa