### PR TITLE
Fix alignment of Go Premium button

### DIFF
--- a/frontend-en/src/components/SideBanners.tsx
+++ b/frontend-en/src/components/SideBanners.tsx
@@ -48,7 +48,7 @@ export default function SideBanners() {
         <h3 className="font-bold mb-1 text-center">Premium</h3>
         <p className="text-sm text-center">Get early price analysis from our experts</p>
         <Link href="/auth/register">
-          <a className="mt-2 inline-block px-3 py-1 bg-white text-green-700 rounded text-sm font-semibold mx-auto">
+          <a className="mt-2 block w-fit px-3 py-1 bg-white text-green-700 rounded text-sm font-semibold mx-auto text-center">
             Go Premium
           </a>
         </Link>


### PR DESCRIPTION
## Summary
- center the Go Premium button on the Premium subscription banner

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68472be05be0832fb01333bb06298677