### PR TITLE
Fix crypto ticker by using public API and skipping optional services

### DIFF
--- a/backend/src/config/cryptoApi.js
+++ b/backend/src/config/cryptoApi.js
@@ -1,12 +1,21 @@
 // cryptoApi.js
 const axios = require('axios');
 
-const api = axios.create({
-  baseURL: 'https://pro-api.coinmarketcap.com/v1',
-  headers: {
-    'X-CMC_PRO_API_KEY': process.env.CMC_API_KEY,
-    'Accept': 'application/json'
-  }
-});
+let api;
+if (process.env.CMC_API_KEY) {
+  api = axios.create({
+    baseURL: 'https://pro-api.coinmarketcap.com/v1',
+    headers: {
+      'X-CMC_PRO_API_KEY': process.env.CMC_API_KEY,
+      'Accept': 'application/json'
+    }
+  });
+} else {
+  console.warn('⚠️  CMC_API_KEY not set. Using CoinGecko public API.');
+  api = axios.create({
+    baseURL: 'https://api.coingecko.com/api/v3',
+    headers: { 'Accept': 'application/json' }
+  });
+}
 
 module.exports = api;

--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -3,8 +3,10 @@ const mongoose = require('mongoose');
 
 const mongoURI = process.env.MONGODB_URI;
 if (!mongoURI) {
-  console.error('❌  MONGODB_URI não definida em .env');
-  process.exit(1);
+  // In dev/test environments the DB may be optional
+  console.warn('⚠️  MONGODB_URI not set, skipping MongoDB connection');
+  module.exports = mongoose;
+  return;
 }
 
 mongoose

--- a/backend/src/config/geoLocation.js
+++ b/backend/src/config/geoLocation.js
@@ -2,14 +2,14 @@
 const IPGeolocationAPI = require('ip-geolocation-api-javascript-sdk');
 
 // Lê a API key e o modo async de variáveis de ambiente
-const API_KEY   = process.env.IPGEO_API_KEY;
-const ASYNC     = process.env.IPGEO_ASYNC === 'true'; // false se não definido
+const API_KEY = process.env.IPGEO_API_KEY;
+const ASYNC = process.env.IPGEO_ASYNC === 'true';
 
-if (!API_KEY) {
-  throw new Error('Missing IPGEO_API_KEY in environment');
+let ipgeolocationApi = null;
+if (API_KEY) {
+  ipgeolocationApi = new IPGeolocationAPI(API_KEY, ASYNC);
+} else {
+  console.warn('⚠️  IPGEO_API_KEY not set. Geolocation features disabled.');
 }
-
-// Instancia o cliente da API
-const ipgeolocationApi = new IPGeolocationAPI(API_KEY, ASYNC);
 
 module.exports = ipgeolocationApi;

--- a/backend/src/config/paymentGateway.js
+++ b/backend/src/config/paymentGateway.js
@@ -2,7 +2,12 @@
 const { Client, resources } = require('coinbase-commerce-node');
 require('dotenv').config();
 
-Client.init(process.env.COINBASE_API_KEY);
+const apiKey = process.env.COINBASE_API_KEY;
+if (apiKey) {
+  Client.init(apiKey);
+} else {
+  console.warn('⚠️  COINBASE_API_KEY not set. Payment features disabled.');
+}
 
 module.exports = {
   resources,               // para criar e recuperar charges

--- a/backend/src/services/crypto.service.js
+++ b/backend/src/services/crypto.service.js
@@ -1,5 +1,6 @@
 // crypto.service.js
 const api = require('../config/cryptoApi');
+const useCMC = !!process.env.CMC_API_KEY;
 
 class CryptoService {
   /**
@@ -8,14 +9,30 @@ class CryptoService {
    * @param {string} convert Moeda fiat para conversão (ex: 'USD,BRL').
    */
   static async getTopCryptos(limit = 10, convert = 'USD') {
-    const response = await api.get('/cryptocurrency/listings/latest', {
-      params: { start: 1, limit, convert }
+    if (useCMC) {
+      const response = await api.get('/cryptocurrency/listings/latest', {
+        params: { start: 1, limit, convert }
+      });
+      return response.data.data.map(c => ({
+        symbol: c.symbol,
+        price: c.quote[convert].price,
+        change24h: c.quote[convert].percent_change_24h
+      }));
+    }
+
+    const vs_currency = convert.toLowerCase();
+    const response = await api.get('/coins/markets', {
+      params: {
+        vs_currency,
+        order: 'market_cap_desc',
+        per_page: limit,
+        page: 1
+      }
     });
-    // retorna [{ symbol, price, percent_change_24h }, ...]
-    return response.data.data.map(c => ({
-      symbol: c.symbol,
-      price: c.quote[convert].price,
-      change24h: c.quote[convert].percent_change_24h
+    return response.data.map(c => ({
+      symbol: c.symbol.toUpperCase(),
+      price: c.current_price,
+      change24h: c.price_change_percentage_24h
     }));
   }
 }


### PR DESCRIPTION
## Summary
- allow backend to start when optional API keys are missing
- switch crypto service to fallback to CoinGecko
- avoid crashes in payment gateway and geolocation when keys are absent

## Testing
- `npx next build` *(fails: next not found)*
- `node backend/src/server.js` *(starts but crypto fetch fails due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68473898e978832fbfbd6bc1388d9da8