### PR TITLE
Fix subscription checkout routing

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -10,10 +10,14 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 // rotas
+const authRoutes       = require('./routes/auth.routes');
+const subscriptionRoutes = require('./routes/subscription.routes');
 const cryptoRoutes     = require('./routes/crypto.routes');
 const newsletterRoutes = require('./routes/newsletter.routes');
 const paymentRoutes    = require('./routes/payment.routes');
 
+app.use('/api/auth',        authRoutes);
+app.use('/api/subscriptions', subscriptionRoutes);
 app.use('/api/crypto',     cryptoRoutes);
 app.use('/api/newsletter', newsletterRoutes);
 app.use('/api/payments',   paymentRoutes);

--- a/backend/src/services/subscription.service.js
+++ b/backend/src/services/subscription.service.js
@@ -1,0 +1,69 @@
+const Subscription = require('../models/Subscription');
+const paymentService = require('./payment.service');
+
+// Preços de exemplo por plano (em USD)
+const planPrices = {
+  diario: 5,
+  semanal: 10,
+  quinzenal: 15,
+  mensal: 20,
+  bimestral: 35,
+  trimestral: 50
+};
+const DEFAULT_CURRENCY = 'USD';
+
+async function createSubscription(userId, plan) {
+  if (!planPrices[plan]) {
+    throw new Error('Plano inválido');
+  }
+
+  let subscription = await Subscription.findOne({ user: userId });
+  if (!subscription) {
+    subscription = await Subscription.create({
+      user: userId,
+      plan,
+      status: 'pending',
+      startDate: new Date()
+    });
+  } else {
+    subscription.plan = plan;
+    subscription.status = 'pending';
+    await subscription.save();
+  }
+
+  const payment = await paymentService.createCharge({
+    userId,
+    plan,
+    amount: planPrices[plan],
+    currency: DEFAULT_CURRENCY
+  });
+
+  return { subscription, paymentLink: payment.hostedUrl };
+}
+
+async function getSubscriptionByUser(userId) {
+  return Subscription.findOne({ user: userId });
+}
+
+async function updateSubscription(userId, plan) {
+  const subscription = await Subscription.findOneAndUpdate(
+    { user: userId },
+    { plan },
+    { new: true }
+  );
+  return subscription;
+}
+
+async function cancelSubscription(userId) {
+  await Subscription.findOneAndUpdate(
+    { user: userId },
+    { status: 'cancelled' }
+  );
+}
+
+module.exports = {
+  createSubscription,
+  getSubscriptionByUser,
+  updateSubscription,
+  cancelSubscription
+};


### PR DESCRIPTION
## Summary
- add subscription service
- expose auth and subscription routes in server

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*
- `node backend/src/server.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684746cce118832f9747d978e09e1949