### PR TITLE
Fix categories API endpoint

### DIFF
--- a/backend/src/controllers/category.controller.js
+++ b/backend/src/controllers/category.controller.js
@@ -21,10 +21,25 @@ exports.createCategory = async (req, res) => {
   }
 };
 
-exports.getCategories = async (req, res) => {
+// Lista todas as categorias
+exports.getAllCategories = async (req, res) => {
   try {
     const categories = await Category.find().lean();
     res.json(categories);
+  } catch {
+    res.status(500).json({ message: 'Erro no servidor.' });
+  }
+};
+
+// Mantido para compatibilidade com código legado
+exports.getCategories = exports.getAllCategories;
+
+// Obtém categoria pelo slug amigável utilizado nas URLs
+exports.getCategoryBySlug = async (req, res) => {
+  try {
+    const cat = await Category.findOne({ slug: req.params.slug }).lean();
+    if (!cat) return res.status(404).json({ message: 'Categoria não encontrada.' });
+    res.json(cat);
   } catch {
     res.status(500).json({ message: 'Erro no servidor.' });
   }


### PR DESCRIPTION
## Summary
- implement `getAllCategories` and `getCategoryBySlug` in category controller
- export backwards-compatible `getCategories`

## Testing
- `npm install` *(backend)*
- `npm install` *(frontend)*
- `npm run lint` *(fails: asks for interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_68474a293098832fab79fba08a7896f1