### PR TITLE
Fix missing subscription handlers causing crash

### DIFF
--- a/backend/src/controllers/subscription.controller.js
+++ b/backend/src/controllers/subscription.controller.js
@@ -13,7 +13,7 @@ exports.createSubscription = async (req, res, next) => {
   }
 };
 
-exports.getSubscription = async (req, res, next) => {
+exports.getMySubscription = async (req, res, next) => {
   try {
     const userId = req.user.id;
     const subscription = await subscriptionService.getSubscriptionByUser(userId);
@@ -42,6 +42,29 @@ exports.cancelSubscription = async (req, res, next) => {
     const userId = req.user.id;
     await subscriptionService.cancelSubscription(userId);
     res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ====== Admin Routes ======
+
+exports.getAllSubscriptions = async (req, res, next) => {
+  try {
+    const subscriptions = await subscriptionService.getAllSubscriptions();
+    res.json({ subscriptions });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.getSubscriptionById = async (req, res, next) => {
+  try {
+    const subscription = await subscriptionService.getSubscriptionById(req.params.id);
+    if (!subscription) {
+      return res.status(404).json({ message: 'Assinatura não encontrada.' });
+    }
+    res.json({ subscription });
   } catch (err) {
     next(err);
   }

--- a/backend/src/services/subscription.service.js
+++ b/backend/src/services/subscription.service.js
@@ -61,9 +61,19 @@ async function cancelSubscription(userId) {
   );
 }
 
+async function getAllSubscriptions() {
+  return Subscription.find().populate('user');
+}
+
+async function getSubscriptionById(id) {
+  return Subscription.findById(id).populate('user');
+}
+
 module.exports = {
   createSubscription,
   getSubscriptionByUser,
   updateSubscription,
-  cancelSubscription
+  cancelSubscription,
+  getAllSubscriptions,
+  getSubscriptionById
 };


### PR DESCRIPTION
## Summary
- implement admin handlers and my-subscription handler
- expose new methods in service layer

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684757a230f4832f8515e958071c4c4a