### PR TITLE
Fix missing authorize middleware

### DIFF
--- a/backend/src/middlewares/auth.middleware.js
+++ b/backend/src/middlewares/auth.middleware.js
@@ -32,3 +32,6 @@ exports.restrictTo = (...allowedRoles) => {
     next();
   };
 };
+
+// Alias para compatibilidade com rotas existentes
+exports.authorize = (...roles) => exports.restrictTo(...roles);


### PR DESCRIPTION
## Summary
- export `authorize` from `auth.middleware.js` for route compatibility

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684759be26fc832fb4eca0ed8ed1545f