### PR TITLE
Update CoinGecko config and reduce API load

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -50,6 +50,8 @@ EMAIL_API_KEY=xkeysib-...
 
 # Coinbase Commerce
 COINBASE_API_KEY=579038d7-0e41-47f9-b643-04a51447220f
+# CoinGecko Demo API
+COINGECKO_API_KEY=your_coingecko_key
 ```
 
 ## Executando

--- a/backend/src/config/cryptoApi.js
+++ b/backend/src/config/cryptoApi.js
@@ -11,10 +11,16 @@ if (process.env.CMC_API_KEY) {
     }
   });
 } else {
-  console.warn('⚠️  CMC_API_KEY not set. Using CoinGecko public API.');
+  console.warn('⚠️  CMC_API_KEY not set. Using CoinGecko API.');
+  const headers = { Accept: 'application/json' };
+  if (process.env.COINGECKO_API_KEY) {
+    headers['x-cg-demo-api-key'] = process.env.COINGECKO_API_KEY;
+  } else {
+    console.warn('⚠️  COINGECKO_API_KEY not set. Using public CoinGecko API which has stricter rate limits.');
+  }
   api = axios.create({
     baseURL: 'https://api.coingecko.com/api/v3',
-    headers: { 'Accept': 'application/json' }
+    headers
   });
 }
 

--- a/backend/src/services/crypto.service.js
+++ b/backend/src/services/crypto.service.js
@@ -1,6 +1,7 @@
 // crypto.service.js
 const api = require('../config/cryptoApi');
 const useCMC = !!process.env.CMC_API_KEY;
+const cache = new Map();
 
 class CryptoService {
   /**
@@ -9,31 +10,42 @@ class CryptoService {
    * @param {string} convert Moeda fiat para conversão (ex: 'USD,BRL').
    */
   static async getTopCryptos(limit = 10, convert = 'USD') {
+    const key = `${limit}_${convert}`;
+    const cached = cache.get(key);
+    const now = Date.now();
+    if (cached && now - cached.ts < 60_000) {
+      return cached.data;
+    }
+
+    let data;
     if (useCMC) {
       const response = await api.get('/cryptocurrency/listings/latest', {
         params: { start: 1, limit, convert }
       });
-      return response.data.data.map(c => ({
+      data = response.data.data.map(c => ({
         symbol: c.symbol,
         price: c.quote[convert].price,
         change24h: c.quote[convert].percent_change_24h
       }));
+    } else {
+      const vs_currency = convert.toLowerCase();
+      const response = await api.get('/coins/markets', {
+        params: {
+          vs_currency,
+          order: 'market_cap_desc',
+          per_page: limit,
+          page: 1
+        }
+      });
+      data = response.data.map(c => ({
+        symbol: c.symbol.toUpperCase(),
+        price: c.current_price,
+        change24h: c.price_change_percentage_24h
+      }));
     }
 
-    const vs_currency = convert.toLowerCase();
-    const response = await api.get('/coins/markets', {
-      params: {
-        vs_currency,
-        order: 'market_cap_desc',
-        per_page: limit,
-        page: 1
-      }
-    });
-    return response.data.map(c => ({
-      symbol: c.symbol.toUpperCase(),
-      price: c.current_price,
-      change24h: c.price_change_percentage_24h
-    }));
+    cache.set(key, { ts: now, data });
+    return data;
   }
 }
 


### PR DESCRIPTION
## Summary
- support CoinGecko API key via `COINGECKO_API_KEY`
- cache crypto price results for 60 seconds
- document new env variable

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6847d8763328832f9f4cbe48334b7c6e