### PR TITLE
Add newsletter subscribe feedback messages

### DIFF
--- a/frontend-en/src/components/NewsletterForm.tsx
+++ b/frontend-en/src/components/NewsletterForm.tsx
@@ -1,25 +1,15 @@
 import { FormEvent, useState } from 'react';
-import apiClient from '../utils/apiClient';
+import { useNewsletter } from '../contexts/NewsletterContext';
 
 export default function NewsletterForm() {
   const [email, setEmail] = useState('');
-  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
-  const [message, setMessage] = useState('');
+  const { subscribe, loading, success, error } = useNewsletter();
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (!email.trim()) return;
-    setStatus('loading');
-    try {
-      await apiClient.post('/api/newsletter/subscribe', { email: email.trim() });
-      setStatus('success');
-      setMessage('Subscribed successfully!');
-      setEmail('');
-    } catch (err) {
-      console.error('Newsletter subscribe error', err);
-      setStatus('error');
-      setMessage('Oops, something went wrong.');
-    }
+    await subscribe(email.trim());
+    setEmail('');
   };
 
   return (
@@ -40,18 +30,14 @@ export default function NewsletterForm() {
 
       <button
         type="submit"
-        disabled={status === 'loading'}
+        disabled={loading}
         className="w-full bg-primary text-white py-2 rounded hover:bg-primary-dark transition disabled:opacity-50"
       >
-        {status === 'loading' ? 'Submitting…' : 'Subscribe'}
+        {loading ? 'Submitting…' : 'Subscribe'}
       </button>
 
-      {status === 'success' && (
-        <p className="mt-2 text-green-600 text-sm">{message}</p>
-      )}
-      {status === 'error' && (
-        <p className="mt-2 text-red-600 text-sm">{message}</p>
-      )}
+      {success && <p className="mt-2 text-green-600 text-sm">{success}</p>}
+      {error && <p className="mt-2 text-red-600 text-sm">{error}</p>}
     </form>
   );
 }

--- a/frontend-en/src/components/SideBanners.tsx
+++ b/frontend-en/src/components/SideBanners.tsx
@@ -5,7 +5,7 @@ import { useNewsletter } from '../contexts/NewsletterContext';
 
 export default function SideBanners() {
   const { user } = useAuth();
-  const { subscribe, isSubscribed, loading } = useNewsletter();
+  const { subscribe, isSubscribed, loading, error, success } = useNewsletter();
   const [email, setEmail] = useState(user?.email ?? '');
 
   const handleSubmit = async (e: FormEvent) => {
@@ -20,8 +20,10 @@ export default function SideBanners() {
       {/* Banner Newsletter */}
       <div className="block w-40 p-4 bg-primary text-white rounded-l-lg shadow text-center">
         <h3 className="font-bold mb-1 text-center">Newsletter</h3>
-        {user && isSubscribed ? (
-          <p className="text-sm">Congrats, you're already subscribed!</p>
+        {success ? (
+          <p className="text-sm">{success}</p>
+        ) : isSubscribed ? (
+          <p className="text-sm">Você já está cadastrado na nossa newsletter.</p>
         ) : (
           <form onSubmit={handleSubmit} className="space-y-2">
             <input
@@ -39,6 +41,9 @@ export default function SideBanners() {
             >
               {loading ? 'Submitting…' : 'Subscribe'}
             </button>
+            {error && (
+              <p className="text-xs text-red-300 text-center mt-1">{error}</p>
+            )}
           </form>
         )}
       </div>


### PR DESCRIPTION
## Summary
- display success/error messages for newsletter subscription
- centralize messages in NewsletterContext

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e883c1a8832fb9aa565dba8bfb78