### PR TITLE
Fix environment variable name for newsletter

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -45,7 +45,7 @@ PORT=3000
 SMTP_PORT=587
 SMTP_USER=seu_usuario
 SMTP_PASS=sua_senha
-NEWSLETTER_LIST_ID=KRMCrypto
+BREVO_LIST_ID=KRMCrypto
 EMAIL_API_KEY=xkeysib-...
 
 # Coinbase Commerce

--- a/backend/src/config/newsletter.js
+++ b/backend/src/config/newsletter.js
@@ -9,9 +9,9 @@ const apiKey = defaultClient.authentications['api-key'];
 apiKey.apiKey = process.env.BREVO_API_KEY || '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';
 
 // O ID da lista KRMCrypto
-const NEWSLETTER_LIST_ID = Number(process.env.BREVO_LIST_ID) || 2;
+const BREVO_LIST_ID = Number(process.env.BREVO_LIST_ID) || 2;
 
 module.exports = {
   SibApiV3Sdk,
-  NEWSLETTER_LIST_ID
+  BREVO_LIST_ID
 };

--- a/backend/src/controllers/newsletter.controller.js
+++ b/backend/src/controllers/newsletter.controller.js
@@ -1,6 +1,6 @@
 // controllers/newsletter.controller.js
 const NewsletterSubscriber = require('../models/NewsletterSubscriber');
-const { SibApiV3Sdk, NEWSLETTER_LIST_ID } = require('../config/newsletter');
+const { SibApiV3Sdk, BREVO_LIST_ID } = require('../config/newsletter');
 
 const contactsApi = new SibApiV3Sdk.ContactsApi();
 
@@ -19,7 +19,7 @@ exports.subscribe = async (req, res) => {
     const createContact = new SibApiV3Sdk.CreateContact();
     createContact.email = email;
     createContact.attributes = { FIRSTNAME: name };
-    createContact.listIds = [NEWSLETTER_LIST_ID];
+    createContact.listIds = [BREVO_LIST_ID];
     createContact.updateEnabled = false; // não sobrescrever contatos existentes
 
     await contactsApi.createContact(createContact);

--- a/backend/src/services/newsletter.service.js
+++ b/backend/src/services/newsletter.service.js
@@ -1,4 +1,4 @@
-const SibApiV3Sdk = require('sib-api-v3-sdk');
+const { SibApiV3Sdk, BREVO_LIST_ID } = require('../config/newsletter');
 const NewsletterSubscriber = require('../models/NewsletterSubscriber');
 const { sendEmail } = require('../utils/email.util');
 
@@ -26,7 +26,7 @@ async function subscribe({ firstName, lastName, email }) {
   const createContact = new SibApiV3Sdk.CreateContact();
   createContact.email = email;
   createContact.attributes = { FIRSTNAME: firstName, LASTNAME: lastName };
-  createContact.listIds = [ Number(process.env.NEWSLETTER_LIST_ID) ];
+  createContact.listIds = [ BREVO_LIST_ID ];
   createContact.updateEnabled = false;
 
   try {
@@ -35,7 +35,7 @@ async function subscribe({ firstName, lastName, email }) {
     // se já existe no Brevo, apenas adiciona à lista
     if (err.response && err.response.body.code === 'duplicate_parameter') {
       const updateContact = new SibApiV3Sdk.UpdateContact();
-      updateContact.listIds = [ Number(process.env.NEWSLETTER_LIST_ID) ];
+      updateContact.listIds = [ BREVO_LIST_ID ];
       await contactsApi.updateContact(email, updateContact);
     } else {
       throw err;


### PR DESCRIPTION
## Summary
- use `BREVO_LIST_ID` everywhere
- document the Brevo list ID in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847eee59ad8832fb7f23c10f8ff6dbc