### PR TITLE
Add environment variable checks

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,5 +1,21 @@
 // src/server.js
 require('dotenv').config();           // carrega .env
+
+// Verifica variáveis de ambiente críticas
+const requiredEnv = [
+  'JWT_SECRET',
+  'SMTP_HOST',
+  'SMTP_PORT',
+  'SMTP_USER',
+  'SMTP_PASSWORD',
+  'EMAIL_FROM'
+];
+
+const missing = requiredEnv.filter((key) => !process.env[key]);
+if (missing.length) {
+  console.error(`❌  Missing required environment variables: ${missing.join(', ')}`);
+  process.exit(1);
+}
 require('./config/database');        // inicializa conexão com MongoDB
 
 const express = require('express');


### PR DESCRIPTION
## Summary
- exit on missing critical environment variables at server startup

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847effcff64832fb365a170e400d3de