### PR TITLE
Enable geolocation-based categories

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -52,6 +52,8 @@ EMAIL_API_KEY=xkeysib-...
 COINBASE_API_KEY=579038d7-0e41-47f9-b643-04a51447220f
 # CoinGecko Demo API
 COINGECKO_API_KEY=your_coingecko_key
+# IP Geolocation
+IPGEO_API_KEY=your_ipgeolocation_key
 ```
 
 ## Executando

--- a/backend/src/routes/category.routes.js
+++ b/backend/src/routes/category.routes.js
@@ -3,9 +3,10 @@ const express = require('express');
 const router = express.Router();
 const categoryController = require('../controllers/category.controller');
 const { protect, authorize } = require('../middlewares/auth.middleware');
+const locationMiddleware = require('../middlewares/location.middleware');
 
 // leitura pública
-router.get('/',        categoryController.getAllCategories);
+router.get('/', locationMiddleware, categoryController.getAllCategories);
 router.get('/:slug',   categoryController.getCategoryBySlug);
 
 // apenas admin pode modificar

--- a/backend/src/routes/geo.routes.js
+++ b/backend/src/routes/geo.routes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+const locationMiddleware = require('../middlewares/location.middleware');
+
+// Returns geolocation info for the requesting IP
+router.get('/', locationMiddleware, (req, res) => {
+  if (!req.location) {
+    return res.status(500).json({ message: 'Geolocation unavailable' });
+  }
+  res.json(req.location);
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -31,12 +31,20 @@ const subscriptionRoutes = require('./routes/subscription.routes');
 const cryptoRoutes     = require('./routes/crypto.routes');
 const newsletterRoutes = require('./routes/newsletter.routes');
 const paymentRoutes    = require('./routes/payment.routes');
+const categoryRoutes   = require('./routes/category.routes');
+const postRoutes       = require('./routes/post.routes');
+const userRoutes       = require('./routes/user.routes');
+const geoRoutes        = require('./routes/geo.routes');
 
 app.use('/api/auth',        authRoutes);
 app.use('/api/subscriptions', subscriptionRoutes);
 app.use('/api/crypto',     cryptoRoutes);
 app.use('/api/newsletter', newsletterRoutes);
 app.use('/api/payments',   paymentRoutes);
+app.use('/api/categories', categoryRoutes);
+app.use('/api/posts',      postRoutes);
+app.use('/api/users',      userRoutes);
+app.use('/api/geo',        geoRoutes);
 
 // health-check
 app.get('/', (req, res) => {

--- a/frontend-en/src/utils/geo.ts
+++ b/frontend-en/src/utils/geo.ts
@@ -1,9 +1,12 @@
 import apiClient from './apiClient';
 
 export interface GeoData {
-  country: string;
-  region?: string;
-  city?: string;
+  ip: string;
+  countryCode2?: string;
+  countryName?: string;
+  continent?: string;
+  timezone?: string;
+  currency?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- document IPGEO_API_KEY environment variable
- use user location in `getAllCategories` controller
- expose `/api/geo` endpoint
- run geolocation middleware for categories
- register new routes on the server
- enhance geo utilities and hook on the frontend to sort categories

## Testing
- `npm install`
- `node backend/src/server.js` *(fails: Missing required environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6847f0b4cbf0832f8801729a15f808f1