### PR TITLE
Fix inconsistent news endpoint

### DIFF
--- a/frontend-en/src/pages/index.tsx
+++ b/frontend-en/src/pages/index.tsx
@@ -15,7 +15,7 @@ export default function HomePage() {
     categories.forEach((cat: Category) => {
       // busca 5 artigos recentes para cada categoria
       apiClient
-        .get<Article[]>(`/api/news?category=${encodeURIComponent(cat.slug)}&limit=5`)
+        .get<Article[]>(`/api/posts?category=${encodeURIComponent(cat.slug)}&limit=5`)
         .then((resp) => {
           setArticlesMap((prev) => ({
             ...prev,

--- a/frontend-en/src/pages/news/Global/index.tsx
+++ b/frontend-en/src/pages/news/Global/index.tsx
@@ -44,7 +44,7 @@ export default function GlobalNewsPage({ articles }: GlobalNewsPageProps) {
 export const getServerSideProps: GetServerSideProps = async () => {
   try {
     const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/news?category=global`
+      `${process.env.NEXT_PUBLIC_API_URL}/api/posts?category=global`
     );
     const articles: Article[] = await res.json();
     return { props: { articles } };

--- a/frontend-en/src/pages/news/Global/slug.tsx
+++ b/frontend-en/src/pages/news/Global/slug.tsx
@@ -35,7 +35,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const { slug } = ctx.params!;
   try {
     const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/news/${encodeURIComponent(slug as string)}`
+      `${process.env.NEXT_PUBLIC_API_URL}/api/posts/${encodeURIComponent(slug as string)}`
     );
     if (!res.ok) {
       return { notFound: true };

--- a/frontend-en/src/pages/news/UK/index.tsx
+++ b/frontend-en/src/pages/news/UK/index.tsx
@@ -44,7 +44,7 @@ export default function UKNewsPage({ articles }: UKNewsPageProps) {
 export const getServerSideProps: GetServerSideProps = async () => {
   try {
     const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/news?category=uk`
+      `${process.env.NEXT_PUBLIC_API_URL}/api/posts?category=uk`
     );
     const articles: Article[] = await res.json();
     return { props: { articles } };

--- a/frontend-en/src/pages/news/UK/slug.tsx
+++ b/frontend-en/src/pages/news/UK/slug.tsx
@@ -35,7 +35,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const { slug } = ctx.params!;
   try {
     const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/news/${encodeURIComponent(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/posts/${encodeURIComponent(
         slug as string
       )}`
     );

--- a/frontend-en/src/pages/news/USA/index.tsx
+++ b/frontend-en/src/pages/news/USA/index.tsx
@@ -44,7 +44,7 @@ export default function USANewsPage({ articles }: USANewsPageProps) {
 export const getServerSideProps: GetServerSideProps = async () => {
   try {
     const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/news?category=usa`
+      `${process.env.NEXT_PUBLIC_API_URL}/api/posts?category=usa`
     );
     const articles: Article[] = await res.json();
     return { props: { articles } };

--- a/frontend-en/src/pages/news/USA/slug.tsx
+++ b/frontend-en/src/pages/news/USA/slug.tsx
@@ -35,7 +35,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const { slug } = ctx.params!;
   try {
     const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/news/${encodeURIComponent(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/posts/${encodeURIComponent(
         slug as string
       )}`
     );


### PR DESCRIPTION
## Summary
- unify article endpoint and use `/api/posts` on the frontend

## Testing
- `npm run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f69d5488832fbbae8da8e2732242