### PR TITLE
Fix README SMTP variable

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -44,7 +44,7 @@ PORT=3000
 # Email (Brevo)\ n SMTP_HOST=smtp-relay.sendinblue.com
 SMTP_PORT=587
 SMTP_USER=seu_usuario
-SMTP_PASS=sua_senha
+SMTP_PASSWORD=sua_senha
 BREVO_LIST_ID=KRMCrypto
 EMAIL_API_KEY=xkeysib-...
 


### PR DESCRIPTION
## Summary
- correct SMTP password variable name in backend README

## Testing
- `npm run`

------
https://chatgpt.com/codex/tasks/task_e_6847f6a73fc4832fa59ea41ef4d52913