### PR TITLE
Fix plan names and switch to CoinGecko API

### DIFF
--- a/backend/src/config/cryptoApi.js
+++ b/backend/src/config/cryptoApi.js
@@ -1,27 +1,16 @@
 // cryptoApi.js
 const axios = require('axios');
 
-let api;
-if (process.env.CMC_API_KEY) {
-  api = axios.create({
-    baseURL: 'https://pro-api.coinmarketcap.com/v1',
-    headers: {
-      'X-CMC_PRO_API_KEY': process.env.CMC_API_KEY,
-      'Accept': 'application/json'
-    }
-  });
+const headers = { Accept: 'application/json' };
+if (process.env.COINGECKO_API_KEY) {
+  headers['x-cg-demo-api-key'] = process.env.COINGECKO_API_KEY;
 } else {
-  console.warn('⚠️  CMC_API_KEY not set. Using CoinGecko API.');
-  const headers = { Accept: 'application/json' };
-  if (process.env.COINGECKO_API_KEY) {
-    headers['x-cg-demo-api-key'] = process.env.COINGECKO_API_KEY;
-  } else {
-    console.warn('⚠️  COINGECKO_API_KEY not set. Using public CoinGecko API which has stricter rate limits.');
-  }
-  api = axios.create({
-    baseURL: 'https://api.coingecko.com/api/v3',
-    headers
-  });
+  console.warn('⚠️  COINGECKO_API_KEY not set. Using public CoinGecko API which has stricter rate limits.');
 }
+
+const api = axios.create({
+  baseURL: 'https://api.coingecko.com/api/v3',
+  headers
+});
 
 module.exports = api;

--- a/backend/src/config/newsletter.js
+++ b/backend/src/config/newsletter.js
@@ -6,7 +6,10 @@ const apiKey = defaultClient.authentications['api-key'];
 
 // Tome cuidado de NÃO comitar sua chave no repo.
 // Defina em .env: BREVO_API_KEY=xkeysib-...
-apiKey.apiKey = process.env.BREVO_API_KEY || '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';
+apiKey.apiKey = process.env.BREVO_API_KEY;
+if (!apiKey.apiKey) {
+  console.warn('⚠️  BREVO_API_KEY not set. Newsletter emails will fail.');
+}
 
 // O ID da lista KRMCrypto
 const BREVO_LIST_ID = Number(process.env.BREVO_LIST_ID) || 2;

--- a/backend/src/controllers/subscription.controller.js
+++ b/backend/src/controllers/subscription.controller.js
@@ -5,7 +5,7 @@ const subscriptionService = require('../services/subscription.service');
 exports.createSubscription = async (req, res, next) => {
   try {
     const userId = req.user.id;
-    const { plan } = req.body; // ex: 'diario', 'semanal', ...
+    const { plan } = req.body; // e.g. 'daily', 'weekly', ...
     const { subscription, paymentLink } = await subscriptionService.createSubscription(userId, plan);
     res.status(201).json({ subscription, paymentLink });
   } catch (err) {

--- a/backend/src/models/Payment.js
+++ b/backend/src/models/Payment.js
@@ -5,7 +5,7 @@ const PaymentSchema = new mongoose.Schema({
   user:        { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   plan:        {
                   type: String,
-                  enum: ['diario','semanal','quinzenal','mensal','bimestral','trimestral'],
+                  enum: ['daily','weekly','biweekly','monthly','bimonthly','quarterly'],
                   required: true
                 },
   amount:      { type: Number, required: true },     // valor em local currency

--- a/backend/src/models/Subscription.js
+++ b/backend/src/models/Subscription.js
@@ -12,12 +12,12 @@ const SubscriptionSchema = new mongoose.Schema({
     type: String,
     required: true,
     enum: [
-      'diario',
-      'semanal',
-      'quinzenal',
-      'mensal',
-      'bimestral',
-      'trimestral'
+      'daily',
+      'weekly',
+      'biweekly',
+      'monthly',
+      'bimonthly',
+      'quarterly'
     ]
   },
   status: {

--- a/backend/src/services/crypto.service.js
+++ b/backend/src/services/crypto.service.js
@@ -1,6 +1,5 @@
 // crypto.service.js
 const api = require('../config/cryptoApi');
-const useCMC = !!process.env.CMC_API_KEY;
 const cache = new Map();
 
 class CryptoService {
@@ -17,32 +16,20 @@ class CryptoService {
       return cached.data;
     }
 
-    let data;
-    if (useCMC) {
-      const response = await api.get('/cryptocurrency/listings/latest', {
-        params: { start: 1, limit, convert }
-      });
-      data = response.data.data.map(c => ({
-        symbol: c.symbol,
-        price: c.quote[convert].price,
-        change24h: c.quote[convert].percent_change_24h
-      }));
-    } else {
-      const vs_currency = convert.toLowerCase();
-      const response = await api.get('/coins/markets', {
-        params: {
-          vs_currency,
-          order: 'market_cap_desc',
-          per_page: limit,
-          page: 1
-        }
-      });
-      data = response.data.map(c => ({
-        symbol: c.symbol.toUpperCase(),
-        price: c.current_price,
-        change24h: c.price_change_percentage_24h
-      }));
-    }
+    const vs_currency = convert.toLowerCase();
+    const response = await api.get('/coins/markets', {
+      params: {
+        vs_currency,
+        order: 'market_cap_desc',
+        per_page: limit,
+        page: 1
+      }
+    });
+    const data = response.data.map(c => ({
+      symbol: c.symbol.toUpperCase(),
+      price: c.current_price,
+      change24h: c.price_change_percentage_24h
+    }));
 
     cache.set(key, { ts: now, data });
     return data;

--- a/backend/src/services/subscription.service.js
+++ b/backend/src/services/subscription.service.js
@@ -1,20 +1,20 @@
 const Subscription = require('../models/Subscription');
 const paymentService = require('./payment.service');
 
-// Preços de exemplo por plano (em USD)
+// Example prices per plan (in USD)
 const planPrices = {
-  diario: 5,
-  semanal: 10,
-  quinzenal: 15,
-  mensal: 20,
-  bimestral: 35,
-  trimestral: 50
+  daily: 5,
+  weekly: 10,
+  biweekly: 15,
+  monthly: 20,
+  bimonthly: 35,
+  quarterly: 50
 };
 const DEFAULT_CURRENCY = 'USD';
 
 async function createSubscription(userId, plan) {
   if (!planPrices[plan]) {
-    throw new Error('Plano inválido');
+    throw new Error('Invalid plan');
   }
 
   let subscription = await Subscription.findOne({ user: userId });

--- a/backend/src/utils/validators.js
+++ b/backend/src/utils/validators.js
@@ -6,8 +6,8 @@ const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$/;
 // Valida planos de assinatura
 const validateSubscription = [
   body('plan')
-    .isIn(['daily', 'weekly', 'fortnightly', 'monthly', 'bimonthly', 'quarterly'])
-    .withMessage('Plan must be one of: daily, weekly, fortnightly, monthly, bimonthly, quarterly'),
+    .isIn(['daily', 'weekly', 'biweekly', 'monthly', 'bimonthly', 'quarterly'])
+    .withMessage('Plan must be one of: daily, weekly, biweekly, monthly, bimonthly, quarterly'),
 ];
 
 // Valida updates de usuário (admin)


### PR DESCRIPTION
## Summary
- remove hardcoded Brevo key from newsletter config
- always use CoinGecko for crypto prices
- rename subscription plans to English
- update validation rules and prices

## Testing
- `npm install`
- `npm start` *(fails: Missing required environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6847f91c3e8c832f8d6d0625dc7c91c8