### PR TITLE
Fix missing slugify dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "jsonwebtoken": "^9.0.0",
         "mongoose": "^6.11.0",
         "nodemailer": "^6.9.11",
-        "sib-api-v3-sdk": "^8.5.0"
+        "sib-api-v3-sdk": "^8.5.0",
+        "slugify": "^1.6.6"
       },
       "devDependencies": {
         "@types/node": "^22.15.30",
@@ -3443,6 +3444,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/smart-buffer": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "mongoose": "^6.11.0",
     "nodemailer": "^6.9.11",
     "sib-api-v3-sdk": "^8.5.0",
-    "express-validator": "^7.2.1"
+    "express-validator": "^7.2.1",
+    "slugify": "^1.6.6"
   },
   "devDependencies": {
     "@types/node": "^22.15.30",


### PR DESCRIPTION
## Summary
- add `slugify` package to dependencies

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848287a7e04832fad177db734121a07