### PR TITLE
Fix Vercel build

### DIFF
--- a/frontend-en/src/components/Navbar/Navbar.tsx
+++ b/frontend-en/src/components/Navbar/Navbar.tsx
@@ -2,8 +2,8 @@
 import { useState, useEffect, useRef } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
-import SearchDropdown from '../SearchDropdown'
-import LoginDropdown from '../LoginDropdown'
+import SearchDropdown from './SearchDropdown'
+import LoginDropdown from './LoginDropdown'
 
 // atualizei apenas aqui:
 const NAV_LINKS = [

--- a/frontend-en/src/pages/news/Global/index.tsx
+++ b/frontend-en/src/pages/news/Global/index.tsx
@@ -11,6 +11,7 @@ const testArticles: Article[] = [
     title: 'test1',
     excerpt: 'test1',
     imageUrl: '/images/test1-global.png',
+    publishedAt: '2023-01-01',
   },
   {
     slug: 'test2',
@@ -18,6 +19,7 @@ const testArticles: Article[] = [
     title: 'test2',
     excerpt: 'test2',
     imageUrl: '/images/test2-global.png',
+    publishedAt: '2023-01-02',
   },
   {
     slug: 'test3',
@@ -25,6 +27,7 @@ const testArticles: Article[] = [
     title: 'test3',
     excerpt: 'test3',
     imageUrl: '/images/test3-global.png',
+    publishedAt: '2023-01-03',
   },
 ];
 

--- a/frontend-en/src/pages/news/UK/index.tsx
+++ b/frontend-en/src/pages/news/UK/index.tsx
@@ -11,6 +11,7 @@ const testArticles: Article[] = [
     title: 'test1',
     excerpt: 'test1',
     imageUrl: '/images/test1-uk.png',
+    publishedAt: '2023-01-01',
   },
   {
     slug: 'test2',
@@ -18,6 +19,7 @@ const testArticles: Article[] = [
     title: 'test2',
     excerpt: 'test2',
     imageUrl: '/images/test2-uk.png',
+    publishedAt: '2023-01-02',
   },
   {
     slug: 'test3',
@@ -25,6 +27,7 @@ const testArticles: Article[] = [
     title: 'test3',
     excerpt: 'test3',
     imageUrl: '/images/test3-uk.png',
+    publishedAt: '2023-01-03',
   },
 ];
 
@@ -32,4 +35,44 @@ interface UKNewsTestIndexProps {
   articles: Article[];
 }
 
-export default
+export default function UKNewsTestIndex({ articles }: UKNewsTestIndexProps) {
+  return (
+    <>
+      <Head>
+        <title>UK News – iDontKnowCrypto (Test)</title>
+        <meta
+          name="description"
+          content="Página de teste UK News com artigos estáticos."
+        />
+      </Head>
+      <main className="max-w-5xl mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold mb-6">UK News (Test)</h1>
+        <div className="space-y-6">
+          {articles.map((article) => (
+            <ArticleCard
+              key={article.slug}
+              slug={article.slug}
+              category={article.category}
+              title={article.title}
+              excerpt={article.excerpt}
+              imageUrl={article.imageUrl}
+            />
+          ))}
+        </div>
+      </main>
+    </>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  try {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/news?category=uk`
+    );
+    const articles: Article[] = await res.json();
+    return { props: { articles } };
+  } catch (err) {
+    console.error('Error fetching UK articles:', err);
+    return { props: { articles: [] } };
+  }
+};

--- a/frontend-en/src/pages/news/index.tsx
+++ b/frontend-en/src/pages/news/index.tsx
@@ -12,6 +12,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test1',
       excerpt: 'test1',
       imageUrl: '/images/test1-uk.png',
+      publishedAt: '2023-01-01',
     },
     {
       slug: 'test2',
@@ -19,6 +20,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test2',
       excerpt: 'test2',
       imageUrl: '/images/test2-uk.png',
+      publishedAt: '2023-01-02',
     },
     {
       slug: 'test3',
@@ -26,6 +28,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test3',
       excerpt: 'test3',
       imageUrl: '/images/test3-uk.png',
+      publishedAt: '2023-01-03',
     },
   ],
   usa: [
@@ -35,6 +38,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test1',
       excerpt: 'test1',
       imageUrl: '/images/test1-usa.png',
+      publishedAt: '2023-01-01',
     },
     {
       slug: 'test2',
@@ -42,6 +46,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test2',
       excerpt: 'test2',
       imageUrl: '/images/test2-usa.png',
+      publishedAt: '2023-01-02',
     },
     {
       slug: 'test3',
@@ -49,6 +54,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test3',
       excerpt: 'test3',
       imageUrl: '/images/test3-usa.png',
+      publishedAt: '2023-01-03',
     },
   ],
   global: [
@@ -58,6 +64,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test1',
       excerpt: 'test1',
       imageUrl: '/images/test1-global.png',
+      publishedAt: '2023-01-01',
     },
     {
       slug: 'test2',
@@ -65,6 +72,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test2',
       excerpt: 'test2',
       imageUrl: '/images/test2-global.png',
+      publishedAt: '2023-01-02',
     },
     {
       slug: 'test3',
@@ -72,6 +80,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test3',
       excerpt: 'test3',
       imageUrl: '/images/test3-global.png',
+      publishedAt: '2023-01-03',
     },
   ],
 };


### PR DESCRIPTION
## Summary
- fix Navbar imports
- add missing `publishedAt` fields to sample articles
- restore UK news page

## Testing
- `npm install` in `frontend-en`
- `npm run build` in `frontend-en`


------
https://chatgpt.com/codex/tasks/task_e_68482acdcbc0832f8d83ba465fd76f6b