### PR TITLE
Fix missing types for sample articles

### DIFF
--- a/frontend-en/src/pages/airdrops/index.tsx
+++ b/frontend-en/src/pages/airdrops/index.tsx
@@ -12,6 +12,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test1',
       excerpt: 'test1',
       imageUrl: '/images/test1-uk.png',
+      publishedAt: '2023-01-01',
     },
     {
       slug: 'test2',
@@ -19,6 +20,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test2',
       excerpt: 'test2',
       imageUrl: '/images/test2-uk.png',
+      publishedAt: '2023-01-02',
     },
     {
       slug: 'test3',
@@ -26,6 +28,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test3',
       excerpt: 'test3',
       imageUrl: '/images/test3-uk.png',
+      publishedAt: '2023-01-03',
     },
   ],
   usa: [
@@ -35,6 +38,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test1',
       excerpt: 'test1',
       imageUrl: '/images/test1-usa.png',
+      publishedAt: '2023-01-01',
     },
     {
       slug: 'test2',
@@ -42,6 +46,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test2',
       excerpt: 'test2',
       imageUrl: '/images/test2-usa.png',
+      publishedAt: '2023-01-02',
     },
     {
       slug: 'test3',
@@ -49,6 +54,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test3',
       excerpt: 'test3',
       imageUrl: '/images/test3-usa.png',
+      publishedAt: '2023-01-03',
     },
   ],
   global: [
@@ -58,6 +64,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test1',
       excerpt: 'test1',
       imageUrl: '/images/test1-global.png',
+      publishedAt: '2023-01-01',
     },
     {
       slug: 'test2',
@@ -65,6 +72,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test2',
       excerpt: 'test2',
       imageUrl: '/images/test2-global.png',
+      publishedAt: '2023-01-02',
     },
     {
       slug: 'test3',
@@ -72,6 +80,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test3',
       excerpt: 'test3',
       imageUrl: '/images/test3-global.png',
+      publishedAt: '2023-01-03',
     },
   ],
 };

--- a/frontend-en/src/pages/bitcoin/Global/index.tsx
+++ b/frontend-en/src/pages/bitcoin/Global/index.tsx
@@ -11,6 +11,7 @@ const testArticles: Article[] = [
     title: 'test1',
     excerpt: 'test1',
     imageUrl: '/images/test1-global.png',
+    publishedAt: '2023-01-01',
   },
   {
     slug: 'test2',
@@ -18,6 +19,7 @@ const testArticles: Article[] = [
     title: 'test2',
     excerpt: 'test2',
     imageUrl: '/images/test2-global.png',
+    publishedAt: '2023-01-02',
   },
   {
     slug: 'test3',
@@ -25,6 +27,7 @@ const testArticles: Article[] = [
     title: 'test3',
     excerpt: 'test3',
     imageUrl: '/images/test3-global.png',
+    publishedAt: '2023-01-03',
   },
 ];
 

--- a/frontend-en/src/pages/bitcoin/index.tsx
+++ b/frontend-en/src/pages/bitcoin/index.tsx
@@ -12,6 +12,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test1',
       excerpt: 'test1',
       imageUrl: '/images/test1-uk.png',
+      publishedAt: '2023-01-01',
     },
     {
       slug: 'test2',
@@ -19,6 +20,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test2',
       excerpt: 'test2',
       imageUrl: '/images/test2-uk.png',
+      publishedAt: '2023-01-02',
     },
     {
       slug: 'test3',
@@ -26,6 +28,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test3',
       excerpt: 'test3',
       imageUrl: '/images/test3-uk.png',
+      publishedAt: '2023-01-03',
     },
   ],
   usa: [
@@ -35,6 +38,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test1',
       excerpt: 'test1',
       imageUrl: '/images/test1-usa.png',
+      publishedAt: '2023-01-01',
     },
     {
       slug: 'test2',
@@ -42,6 +46,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test2',
       excerpt: 'test2',
       imageUrl: '/images/test2-usa.png',
+      publishedAt: '2023-01-02',
     },
     {
       slug: 'test3',
@@ -49,6 +54,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test3',
       excerpt: 'test3',
       imageUrl: '/images/test3-usa.png',
+      publishedAt: '2023-01-03',
     },
   ],
   global: [
@@ -58,6 +64,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test1',
       excerpt: 'test1',
       imageUrl: '/images/test1-global.png',
+      publishedAt: '2023-01-01',
     },
     {
       slug: 'test2',
@@ -65,6 +72,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test2',
       excerpt: 'test2',
       imageUrl: '/images/test2-global.png',
+      publishedAt: '2023-01-02',
     },
     {
       slug: 'test3',
@@ -72,6 +80,7 @@ const testArticles: Record<string, Article[]> = {
       title: 'test3',
       excerpt: 'test3',
       imageUrl: '/images/test3-global.png',
+      publishedAt: '2023-01-03',
     },
   ],
 };

--- a/frontend-en/src/pages/guides/index.tsx
+++ b/frontend-en/src/pages/guides/index.tsx
@@ -1,6 +1,6 @@
 // src/pages/bitcoin/Global/test1.tsx
 import Head from 'next/head';
-import { formatDate } from '../../../utils/date';
+import { formatDate } from '../../utils/date';
 
 export default function BitcoinGlobalTest1Page() {
   const now = new Date().toISOString();

--- a/frontend-en/src/pages/presale/Global/index.tsx
+++ b/frontend-en/src/pages/presale/Global/index.tsx
@@ -11,6 +11,7 @@ const testArticles: Article[] = [
     title: 'test1',
     excerpt: 'test1',
     imageUrl: '/images/test1-global.png',
+    publishedAt: '2023-01-01',
   },
   {
     slug: 'test2',
@@ -18,6 +19,7 @@ const testArticles: Article[] = [
     title: 'test2',
     excerpt: 'test2',
     imageUrl: '/images/test2-global.png',
+    publishedAt: '2023-01-02',
   },
   {
     slug: 'test3',
@@ -25,6 +27,7 @@ const testArticles: Article[] = [
     title: 'test3',
     excerpt: 'test3',
     imageUrl: '/images/test3-global.png',
+    publishedAt: '2023-01-03',
   },
 ];
 

--- a/frontend-en/src/pages/presale/UK/index.tsx
+++ b/frontend-en/src/pages/presale/UK/index.tsx
@@ -11,6 +11,7 @@ const testArticles: Article[] = [
     title: 'test1',
     excerpt: 'test1',
     imageUrl: '/images/test1-uk.png',
+    publishedAt: '2023-01-01',
   },
   {
     slug: 'test2',
@@ -18,6 +19,7 @@ const testArticles: Article[] = [
     title: 'test2',
     excerpt: 'test2',
     imageUrl: '/images/test2-uk.png',
+    publishedAt: '2023-01-02',
   },
   {
     slug: 'test3',
@@ -25,6 +27,7 @@ const testArticles: Article[] = [
     title: 'test3',
     excerpt: 'test3',
     imageUrl: '/images/test3-uk.png',
+    publishedAt: '2023-01-03',
   },
 ];
 

--- a/frontend-en/src/pages/presale/USA/index.tsx
+++ b/frontend-en/src/pages/presale/USA/index.tsx
@@ -11,6 +11,7 @@ const testArticles: Article[] = [
     title: 'test1',
     excerpt: 'test1',
     imageUrl: '/images/test1-usa.png',
+    publishedAt: '2023-01-01',
   },
   {
     slug: 'test2',
@@ -18,6 +19,7 @@ const testArticles: Article[] = [
     title: 'test2',
     excerpt: 'test2',
     imageUrl: '/images/test2-usa.png',
+    publishedAt: '2023-01-02',
   },
   {
     slug: 'test3',
@@ -25,6 +27,7 @@ const testArticles: Article[] = [
     title: 'test3',
     excerpt: 'test3',
     imageUrl: '/images/test3-usa.png',
+    publishedAt: '2023-01-03',
   },
 ];
 

--- a/frontend-en/src/pages/presale/index.tsx
+++ b/frontend-en/src/pages/presale/index.tsx
@@ -1,0 +1,3 @@
+export default function PresaleHome() {
+  return <div>Presale Home</div>;
+}


### PR DESCRIPTION
## Summary
- add `publishedAt` fields to various sample articles
- correct import path in guides sample
- add placeholder page to `/presale`

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68484ee16a48832fac7676da15699c2e