### PR TITLE
Fix newsletter subscription

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -86,7 +86,7 @@ npm start
 * `POST /api/auth/register` – cadastro de usuário
 * `POST /api/auth/login` – login JWT
 * `GET /api/subscriptions/me` – dados da assinatura do usuário
-* `POST /api/newsletter/subscribe` – cadastra email na newsletter
+* `POST /api/newsletter/subscribe` – cadastra email na newsletter. Envie `{ email, name? }` no corpo (nome opcional)
 * `GET /api/crypto/prices` – lista de preços de criptos
 
 Para detalhes de todas as rotas, veja a documentação Swagger (se implementado).

--- a/backend/src/routes/newsletter.routes.js
+++ b/backend/src/routes/newsletter.routes.js
@@ -3,14 +3,15 @@ const express = require('express');
 const router = express.Router();
 const newsletterService = require('../services/newsletter.service');
 
-router.post('/', async (req, res) => {
+// accepts optional name and required email
+router.post('/subscribe', async (req, res) => {
   const { name, email } = req.body;
-  if (!name || !email) {
-    return res.status(400).json({ message: 'Nome e e-mail são obrigatórios.' });
+  if (!email) {
+    return res.status(400).json({ message: 'E-mail é obrigatório.' });
   }
 
   try {
-    const [firstName, ...rest] = name.trim().split(' ');
+    const [firstName, ...rest] = (name || '').trim().split(' ');
     const lastName = rest.join(' ');
 
     const subscriber = await newsletterService.subscribe({ firstName, lastName, email });

--- a/frontend-en/src/components/NewsletterForm.tsx
+++ b/frontend-en/src/components/NewsletterForm.tsx
@@ -15,6 +15,7 @@ export default function NewsletterForm() {
   return (
     <form
       onSubmit={handleSubmit}
+      noValidate
       className="w-full max-w-sm bg-white p-4 rounded-lg shadow"
     >
       <h3 className="text-lg font-semibold mb-2">Join our Newsletter</h3>

--- a/frontend-en/src/components/SideBanners.tsx
+++ b/frontend-en/src/components/SideBanners.tsx
@@ -25,7 +25,7 @@ export default function SideBanners() {
         ) : isSubscribed ? (
           <p className="text-sm">Você já está cadastrado na nossa newsletter.</p>
         ) : (
-          <form onSubmit={handleSubmit} className="space-y-2">
+          <form onSubmit={handleSubmit} noValidate className="space-y-2">
             <input
               type="email"
               value={email}


### PR DESCRIPTION
## Summary
- adjust newsletter endpoint to `/api/newsletter/subscribe`
- make name optional when subscribing
- disable native form validation on newsletter forms
- document optional name parameter

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68491c0cddec832fbe39f101591c2e33