### PR TITLE
Fix CSS import paths for Next.js build

### DIFF
--- a/frontend-pt/src/styles/globals.css
+++ b/frontend-pt/src/styles/globals.css
@@ -1,10 +1,10 @@
 /* src/styles/globals.css */
 
 /* 1. Component-level CSS */
-@import './components/_navbar.css';
-@import './components/_ticker.css';
-@import './components/_carousel.css';
-@import './components/_footer.css';
+@import './_navbar.css';
+@import './_ticker.css';
+@import './_carousel.css';
+@import './_footer.css';
 
 /* 2. Tailwind base + components + utilities */
 @tailwind base;

--- a/frontend-pt/tailwind.config.js
+++ b/frontend-pt/tailwind.config.js
@@ -6,7 +6,7 @@ module.exports = {
     './src/hooks/**/*.{js,ts,tsx}',
     './src/contexts/**/*.{js,ts,tsx}',
     './src/utils/**/*.{js,ts,tsx}',
-    './src/styles/components/**/*.css',
+    './src/styles/**/*.css',
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- correct CSS imports in `globals.css`
- update Tailwind content paths

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858348fadb8832fbcf2cfa3ffc229f7