### PR TITLE
Adjust PT footer text width and links

### DIFF
--- a/frontend-pt/src/components/Footer.tsx
+++ b/frontend-pt/src/components/Footer.tsx
@@ -4,15 +4,15 @@ export default function Footer() {
   return (
     <footer className="bg-footer-bg text-gray-200 py-8 mt-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-3 text-center">
-        <p className="text-sm md:max-w-xl mx-auto whitespace-nowrap overflow-x-auto">
+        <p className="text-sm md:max-w-xl lg:max-w-3xl mx-auto whitespace-nowrap overflow-x-auto lg:overflow-visible">
           Este site fornece informações apenas para fins educacionais. Não é aconselhamento financeiro.
         </p>
 
         <div className="flex justify-center space-x-6">
-          <Link href="/sobre">
+          <Link href="/sobre-nos">
             <a className="text-footer-link hover:text-nav-primary-dark hover:underline">Sobre</a>
           </Link>
-          <Link href="/termos">
+          <Link href="/termos-condicoes">
             <a className="text-footer-link hover:text-nav-primary-dark hover:underline">Termos e Condições</a>
           </Link>
           <Link href="/contato">


### PR DESCRIPTION
## Summary
- footer: allow disclaimer text to expand on large screens
- footer: fix navigation links to correct Portuguese pages

## Testing
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_68583fd89754832fb26e0d8d287d8acb