### PR TITLE
Fix search dropdown alignment

### DIFF
--- a/frontend-en/src/components/Navbar/Navbar.tsx
+++ b/frontend-en/src/components/Navbar/Navbar.tsx
@@ -108,9 +108,12 @@ export default function Navbar() {
               Log in
             </button>
           </div>
-        </div>
+            {isSearchOpen && (
+              <SearchDropdown onClose={() => setIsSearchOpen(false)} />
+            )}
+          </div>
 
-        {/* Mobile menu */}
+          {/* Mobile menu */}
         {isMenuOpen && (
           <div className="md:hidden absolute top-full left-0 right-0 bg-white shadow border-t z-40">
             {NAV_LINKS.map((link) => (
@@ -123,8 +126,7 @@ export default function Navbar() {
         )}
 
         {/* Dropdowns */}
-        {isSearchOpen && <SearchDropdown onClose={() => setIsSearchOpen(false)} />}
-        {isLoginOpen  && <LoginDropdown onClose={() => setIsLoginOpen(false)} />}
+        {isLoginOpen && <LoginDropdown onClose={() => setIsLoginOpen(false)} />}
       </nav>
 
       {/* Spacer para evitar overlap */}

--- a/frontend-pt/src/components/Navbar/Navbar.tsx
+++ b/frontend-pt/src/components/Navbar/Navbar.tsx
@@ -34,7 +34,7 @@ export default function Navbar() {
   return (
     <>
       <nav ref={navRef} className="fixed top-0 left-0 right-0 z-50 bg-white shadow">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
           {/* Logo */}
           <Link href="/">
             <a className="flex-shrink-0">
@@ -94,9 +94,12 @@ export default function Navbar() {
               </svg>
             </button>
           </div>
-        </div>
+            {isSearchOpen && (
+              <SearchDropdown onClose={() => setIsSearchOpen(false)} />
+            )}
+          </div>
 
-        {/* Mobile menu */}
+          {/* Mobile menu */}
         {isMenuOpen && (
           <div className="md:hidden absolute top-full left-0 right-0 bg-white shadow border-t z-40">
             {NAV_LINKS.map(link => {
@@ -114,9 +117,6 @@ export default function Navbar() {
             })}
           </div>
         )}
-
-        {/* Dropdown de busca */}
-        {isSearchOpen && <SearchDropdown onClose={() => setIsSearchOpen(false)} />}
       </nav>
 
       {/* Spacer para evitar overlap */}


### PR DESCRIPTION
## Summary
- ensure Navbar containers are relative and render SearchDropdown inside them
- remove old search dropdown markup

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` in `frontend-pt` *(fails: Next.js not found/ESLint prompt)*
- `npm run lint` in `frontend-en` *(fails: Next.js not found/ESLint prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68584372e728832faa5f958d80985b06