### PR TITLE
Ajustar search e rodapé

### DIFF
--- a/frontend-en/src/styles/globals.css
+++ b/frontend-en/src/styles/globals.css
@@ -39,3 +39,15 @@ a {
 .no-scrollbar::-webkit-scrollbar {
   display: none;
 }
+
+/* Subtle thin scrollbar */
+.thin-scrollbar {
+  scrollbar-width: thin;
+}
+.thin-scrollbar::-webkit-scrollbar {
+  height: 6px;
+}
+.thin-scrollbar::-webkit-scrollbar-thumb {
+  background-color: rgba(155, 107, 212, 0.6);
+  border-radius: 6px;
+}

--- a/frontend-pt/src/components/Footer.tsx
+++ b/frontend-pt/src/components/Footer.tsx
@@ -4,7 +4,7 @@ export default function Footer() {
   return (
     <footer className="bg-footer-bg text-gray-200 py-8 mt-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-3 text-center">
-        <p className="text-sm md:max-w-xl lg:max-w-3xl mx-auto whitespace-nowrap overflow-x-auto lg:overflow-visible">
+        <p className="text-sm md:max-w-xl lg:max-w-3xl mx-auto whitespace-nowrap overflow-x-auto lg:overflow-visible thin-scrollbar">
           Este site fornece informações apenas para fins educacionais. Não é aconselhamento financeiro.
         </p>
 

--- a/frontend-pt/src/components/Navbar/SearchDropdown.tsx
+++ b/frontend-pt/src/components/Navbar/SearchDropdown.tsx
@@ -32,7 +32,7 @@ export default function SearchDropdown({ onClose }: SearchDropdownProps) {
   return (
     <div
       ref={ref}
-      className="absolute right-4 top-full mt-2 bg-white p-4 shadow rounded w-64 z-40"
+      className="absolute right-4 top-full mt-2 bg-white p-4 shadow rounded w-56 z-40"
     >
       <form onSubmit={handleSubmit} className="flex space-x-2">
         <input

--- a/frontend-pt/src/styles/globals.css
+++ b/frontend-pt/src/styles/globals.css
@@ -36,3 +36,15 @@ a {
 .no-scrollbar::-webkit-scrollbar {
   display: none;
 }
+
+/* Scrollbar fina e discreta */
+.thin-scrollbar {
+  scrollbar-width: thin;
+}
+.thin-scrollbar::-webkit-scrollbar {
+  height: 6px;
+}
+.thin-scrollbar::-webkit-scrollbar-thumb {
+  background-color: rgba(155, 107, 212, 0.6);
+  border-radius: 6px;
+}


### PR DESCRIPTION
## Summary
- make thin scrollbar utility for both frontends
- apply subtle scrollbar to PT footer disclaimer
- shrink PT search dropdown width

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685846560b34832f9a72b698d29903a2