### PR TITLE
Ajusta busca e scrollbar no frontend pt

### DIFF
--- a/frontend-pt/src/components/Footer.tsx
+++ b/frontend-pt/src/components/Footer.tsx
@@ -4,7 +4,7 @@ export default function Footer() {
   return (
     <footer className="bg-footer-bg text-gray-200 py-8 mt-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-3 text-center">
-        <p className="text-sm md:max-w-xl lg:max-w-3xl mx-auto whitespace-nowrap overflow-x-auto lg:overflow-visible thin-scrollbar">
+        <p className="text-sm md:max-w-xl lg:max-w-3xl mx-auto whitespace-nowrap overflow-x-auto lg:overflow-visible footer-scrollbar">
           Este site fornece informações apenas para fins educacionais. Não é aconselhamento financeiro.
         </p>
 

--- a/frontend-pt/src/components/Navbar/SearchDropdown.tsx
+++ b/frontend-pt/src/components/Navbar/SearchDropdown.tsx
@@ -32,7 +32,7 @@ export default function SearchDropdown({ onClose }: SearchDropdownProps) {
   return (
     <div
       ref={ref}
-      className="absolute right-4 top-full mt-2 bg-white p-4 shadow rounded w-56 z-40"
+      className="absolute right-20 top-full mt-2 bg-white p-4 shadow rounded w-56 z-40"
     >
       <form onSubmit={handleSubmit} className="flex space-x-2">
         <input

--- a/frontend-pt/src/styles/_footer.css
+++ b/frontend-pt/src/styles/_footer.css
@@ -15,4 +15,26 @@
   .footer-copy {
     @apply text-sm mt-4;
   }
+
+  /* Scrollbar que combina com o rodapé e aparece apenas no hover */
+  .footer-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: transparent #431464;
+  }
+  .footer-scrollbar::-webkit-scrollbar {
+    height: 6px;
+  }
+  .footer-scrollbar::-webkit-scrollbar-track {
+    background-color: #431464;
+  }
+  .footer-scrollbar::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 6px;
+  }
+  .footer-scrollbar:hover {
+    scrollbar-color: #9b6bd4 #431464;
+  }
+  .footer-scrollbar:hover::-webkit-scrollbar-thumb {
+    background-color: #9b6bd4;
+  }
 }


### PR DESCRIPTION
## Summary
- move a caixa de busca mais para a esquerda no dropdown
- harmoniza a barra de rolagem do rodapé e só exibe ao passar o mouse

## Testing
- `npm run lint` *(falha: `next` not found)*
- `npm run lint` em frontend-en *(falha: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584a188120832fa88752dac42e58c3