### PR TITLE
Fix crypto price API in frontend-pt

### DIFF
--- a/frontend-pt/.env.local
+++ b/frontend-pt/.env.local
@@ -1,0 +1,2 @@
+# URL do seu backend (usado em apiClient.ts)
+NEXT_PUBLIC_API_URL=localhost:3000

--- a/frontend-pt/next-config.js
+++ b/frontend-pt/next-config.js
@@ -5,6 +5,9 @@ const nextConfig = {
   images: {
     domains: ['krmcrypto.onrender.com'],
   },
+  env: {
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
## Summary
- expose API URL in pt Next.js config
- add missing `.env.local` to pt frontend

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584bced100832fa9fb121c0da640b5