### PR TITLE
Update frontend-pt to use WordPress backend

### DIFF
--- a/frontend-pt/.env.local
+++ b/frontend-pt/.env.local
@@ -1,2 +1,2 @@
 # URL do seu backend (usado em apiClient.ts)
-NEXT_PUBLIC_API_URL=localhost:3000
+NEXT_PUBLIC_API_URL=https://naoseicripto.com/wp-json/jsbackend/v1

--- a/frontend-pt/src/components/CryptoTicker.tsx
+++ b/frontend-pt/src/components/CryptoTicker.tsx
@@ -13,7 +13,7 @@ export default function CryptoTicker() {
   useEffect(() => {
     async function fetchPrices() {
       try {
-        const resp = await apiClient.get<CryptoPrice[]>('/api/crypto/ticker')
+        const resp = await apiClient.get<CryptoPrice[]>('/ticker')
         setPrices(resp.data)
       } catch (err) {
         console.error('Falha ao carregar preços de cripto', err)

--- a/frontend-pt/src/contexts/CryptoContext.tsx
+++ b/frontend-pt/src/contexts/CryptoContext.tsx
@@ -29,7 +29,7 @@ export function CryptoProvider({ children }: { children: ReactNode }) {
       setLoading(true)
       setError(null)
       try {
-        const resp = await apiClient.get<CryptoPrice[]>('/api/crypto/ticker')
+        const resp = await apiClient.get<CryptoPrice[]>('/ticker')
         setPrices(resp.data)
       } catch (err: any) {
         console.error('Falha ao carregar preços de criptomoedas', err)

--- a/frontend-pt/src/hooks/useGeoCategories.ts
+++ b/frontend-pt/src/hooks/useGeoCategories.ts
@@ -28,7 +28,7 @@ export default function useGeoCategories(): GeoCategoriesHook {
       setError(null)
       try {
         // busca lista completa de categorias
-        const resp = await apiClient.get<Category[]>('/api/categories')
+        const resp = await apiClient.get<Category[]>('/categories')
         let lista = resp.data
 
         // tenta obter país do usuário

--- a/frontend-pt/src/pages/Africa/index.tsx
+++ b/frontend-pt/src/pages/Africa/index.tsx
@@ -13,7 +13,7 @@ export default function AfricaPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/api/articles?category=africa'
+          '/posts?category=africa'
         )
         setArticles(resp.data)
       } catch (err) {

--- a/frontend-pt/src/pages/Brasil/index.tsx
+++ b/frontend-pt/src/pages/Brasil/index.tsx
@@ -13,7 +13,7 @@ export default function BrasilPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/api/articles?category=brasil'
+          '/posts?category=brasil'
         )
         setArticles(resp.data)
       } catch (err) {

--- a/frontend-pt/src/pages/Global/index.tsx
+++ b/frontend-pt/src/pages/Global/index.tsx
@@ -13,7 +13,7 @@ export default function GlobalPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/api/articles?category=global'
+          '/posts?category=global'
         )
         setArticles(resp.data)
       } catch (err) {

--- a/frontend-pt/src/pages/Portugal/index.tsx
+++ b/frontend-pt/src/pages/Portugal/index.tsx
@@ -13,7 +13,7 @@ export default function PortugalPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/api/articles?category=portugal'
+          '/posts?category=portugal'
         )
         setArticles(resp.data)
       } catch (err) {

--- a/frontend-pt/src/pages/altcoins/index.tsx
+++ b/frontend-pt/src/pages/altcoins/index.tsx
@@ -13,7 +13,7 @@ export default function AltcoinsPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/api/articles?subcategory=altcoins'
+          '/posts?subcategory=altcoins'
         )
         setArticles(resp.data)
       } catch (err) {

--- a/frontend-pt/src/pages/bitcoin/index.tsx
+++ b/frontend-pt/src/pages/bitcoin/index.tsx
@@ -13,7 +13,7 @@ export default function BitcoinPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/api/articles?subcategory=bitcoin'
+          '/posts?subcategory=bitcoin'
         )
         setArticles(resp.data)
       } catch (err) {

--- a/frontend-pt/src/pages/blockchain/index.tsx
+++ b/frontend-pt/src/pages/blockchain/index.tsx
@@ -13,7 +13,7 @@ export default function BlockchainPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/api/articles?subcategory=blockchain'
+          '/posts?subcategory=blockchain'
         )
         setArticles(resp.data)
       } catch {

--- a/frontend-pt/src/pages/defi/index.tsx
+++ b/frontend-pt/src/pages/defi/index.tsx
@@ -13,7 +13,7 @@ export default function DeFiPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/api/articles?subcategory=defi'
+          '/posts?subcategory=defi'
         )
         setArticles(resp.data)
       } catch {

--- a/frontend-pt/src/pages/ethereum/index.tsx
+++ b/frontend-pt/src/pages/ethereum/index.tsx
@@ -13,7 +13,7 @@ export default function EthereumPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/api/articles?subcategory=ethereum'
+          '/posts?subcategory=ethereum'
         )
         setArticles(resp.data)
       } catch {

--- a/frontend-pt/src/pages/nft/index.tsx
+++ b/frontend-pt/src/pages/nft/index.tsx
@@ -13,7 +13,7 @@ export default function NFTPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/api/articles?subcategory=nft'
+          '/posts?subcategory=nft'
         )
         setArticles(resp.data)
       } catch {

--- a/frontend-pt/src/pages/regulacao/index.tsx
+++ b/frontend-pt/src/pages/regulacao/index.tsx
@@ -13,7 +13,7 @@ export default function RegulacaoPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/api/articles?subcategory=regulacao'
+          '/posts?subcategory=regulacao'
         )
         setArticles(resp.data)
       } catch {

--- a/frontend-pt/src/utils/geo.ts
+++ b/frontend-pt/src/utils/geo.ts
@@ -10,10 +10,10 @@ export interface GeoData {
 }
 
 /**
- * Busca a geolocalização do usuário na rota /api/geo.
+ * Busca a geolocalização do usuário na rota /geo.
  * Retorna pelo menos o nome ou código do país.
  */
 export async function fetchUserGeo(): Promise<GeoData> {
-  const resp = await apiClient.get<GeoData>('/api/geo')
+  const resp = await apiClient.get<GeoData>('/geo')
   return resp.data
 }


### PR DESCRIPTION
## Summary
- change pt frontend endpoints to match WordPress plugin routes
- set new API base URL

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68584e43762c832f99a53a461efe81b9