### PR TITLE
Fix crypto ticker endpoint for pt frontend

### DIFF
--- a/frontend-pt/.env.local
+++ b/frontend-pt/.env.local
@@ -1,2 +1,2 @@
 # URL do seu backend (usado em apiClient.ts)
-NEXT_PUBLIC_API_URL=https://naoseicripto.com/wp-json/jsbackend/v1
+NEXT_PUBLIC_API_URL=localhost:3000

--- a/frontend-pt/src/components/CryptoTicker.tsx
+++ b/frontend-pt/src/components/CryptoTicker.tsx
@@ -13,7 +13,7 @@ export default function CryptoTicker() {
   useEffect(() => {
     async function fetchPrices() {
       try {
-        const resp = await apiClient.get<CryptoPrice[]>('/ticker')
+        const resp = await apiClient.get<CryptoPrice[]>('/api/crypto/ticker')
         setPrices(resp.data)
       } catch (err) {
         console.error('Falha ao carregar preços de cripto', err)

--- a/frontend-pt/src/contexts/CryptoContext.tsx
+++ b/frontend-pt/src/contexts/CryptoContext.tsx
@@ -29,7 +29,7 @@ export function CryptoProvider({ children }: { children: ReactNode }) {
       setLoading(true)
       setError(null)
       try {
-        const resp = await apiClient.get<CryptoPrice[]>('/ticker')
+        const resp = await apiClient.get<CryptoPrice[]>('/api/crypto/ticker')
         setPrices(resp.data)
       } catch (err: any) {
         console.error('Falha ao carregar preços de criptomoedas', err)


### PR DESCRIPTION
## Summary
- restore `/api/crypto/ticker` endpoint usage in the PT frontend
- point PT frontend back to Node backend URL

## Testing
- `npm install`
- `npm start` *(fails: Missing required environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_685851a6ae7c832fa18e05deda1ba800