### PR TITLE
Limit proxy change to pt frontend

### DIFF
--- a/frontend-pt/.env.local
+++ b/frontend-pt/.env.local
@@ -1,2 +1,2 @@
 # URL do seu backend (usado em apiClient.ts)
-NEXT_PUBLIC_API_URL=localhost:3000
+NEXT_PUBLIC_API_URL=https://naoseicripto.com/wp-json/jsbackend/v1

--- a/frontend-pt/next-config.js
+++ b/frontend-pt/next-config.js
@@ -3,7 +3,7 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   images: {
-    domains: ['krmcrypto.onrender.com'],
+    domains: ['naoseicripto.com'],
   },
   env: {
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,

--- a/frontend-pt/src/components/CryptoTicker.tsx
+++ b/frontend-pt/src/components/CryptoTicker.tsx
@@ -13,7 +13,7 @@ export default function CryptoTicker() {
   useEffect(() => {
     async function fetchPrices() {
       try {
-        const resp = await apiClient.get<CryptoPrice[]>('/api/crypto/ticker')
+        const resp = await apiClient.get<CryptoPrice[]>('/ticker')
         setPrices(resp.data)
       } catch (err) {
         console.error('Falha ao carregar preços de cripto', err)

--- a/frontend-pt/src/contexts/CryptoContext.tsx
+++ b/frontend-pt/src/contexts/CryptoContext.tsx
@@ -29,7 +29,7 @@ export function CryptoProvider({ children }: { children: ReactNode }) {
       setLoading(true)
       setError(null)
       try {
-        const resp = await apiClient.get<CryptoPrice[]>('/api/crypto/ticker')
+        const resp = await apiClient.get<CryptoPrice[]>('/ticker')
         setPrices(resp.data)
       } catch (err: any) {
         console.error('Falha ao carregar preços de criptomoedas', err)

--- a/frontend-pt/src/pages/Africa/index.tsx
+++ b/frontend-pt/src/pages/Africa/index.tsx
@@ -13,7 +13,7 @@ export default function AfricaPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/posts?category=africa'
+          '/articles?category=africa'
         )
         setArticles(resp.data)
       } catch (err) {

--- a/frontend-pt/src/pages/Brasil/index.tsx
+++ b/frontend-pt/src/pages/Brasil/index.tsx
@@ -13,7 +13,7 @@ export default function BrasilPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/posts?category=brasil'
+          '/articles?category=brasil'
         )
         setArticles(resp.data)
       } catch (err) {

--- a/frontend-pt/src/pages/Global/index.tsx
+++ b/frontend-pt/src/pages/Global/index.tsx
@@ -13,7 +13,7 @@ export default function GlobalPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/posts?category=global'
+          '/articles?category=global'
         )
         setArticles(resp.data)
       } catch (err) {

--- a/frontend-pt/src/pages/Portugal/index.tsx
+++ b/frontend-pt/src/pages/Portugal/index.tsx
@@ -13,7 +13,7 @@ export default function PortugalPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/posts?category=portugal'
+          '/articles?category=portugal'
         )
         setArticles(resp.data)
       } catch (err) {

--- a/frontend-pt/src/pages/altcoins/index.tsx
+++ b/frontend-pt/src/pages/altcoins/index.tsx
@@ -13,7 +13,7 @@ export default function AltcoinsPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/posts?subcategory=altcoins'
+          '/articles?subcategory=altcoins'
         )
         setArticles(resp.data)
       } catch (err) {

--- a/frontend-pt/src/pages/bitcoin/index.tsx
+++ b/frontend-pt/src/pages/bitcoin/index.tsx
@@ -13,7 +13,7 @@ export default function BitcoinPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/posts?subcategory=bitcoin'
+          '/articles?subcategory=bitcoin'
         )
         setArticles(resp.data)
       } catch (err) {

--- a/frontend-pt/src/pages/blockchain/index.tsx
+++ b/frontend-pt/src/pages/blockchain/index.tsx
@@ -13,7 +13,7 @@ export default function BlockchainPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/posts?subcategory=blockchain'
+          '/articles?subcategory=blockchain'
         )
         setArticles(resp.data)
       } catch {

--- a/frontend-pt/src/pages/defi/index.tsx
+++ b/frontend-pt/src/pages/defi/index.tsx
@@ -13,7 +13,7 @@ export default function DeFiPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/posts?subcategory=defi'
+          '/articles?subcategory=defi'
         )
         setArticles(resp.data)
       } catch {

--- a/frontend-pt/src/pages/ethereum/index.tsx
+++ b/frontend-pt/src/pages/ethereum/index.tsx
@@ -13,7 +13,7 @@ export default function EthereumPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/posts?subcategory=ethereum'
+          '/articles?subcategory=ethereum'
         )
         setArticles(resp.data)
       } catch {

--- a/frontend-pt/src/pages/nft/index.tsx
+++ b/frontend-pt/src/pages/nft/index.tsx
@@ -13,7 +13,7 @@ export default function NFTPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/posts?subcategory=nft'
+          '/articles?subcategory=nft'
         )
         setArticles(resp.data)
       } catch {

--- a/frontend-pt/src/pages/regulacao/index.tsx
+++ b/frontend-pt/src/pages/regulacao/index.tsx
@@ -13,7 +13,7 @@ export default function RegulacaoPage() {
     async function fetchArticles() {
       try {
         const resp = await apiClient.get<Article[]>(
-          '/posts?subcategory=regulacao'
+          '/articles?subcategory=regulacao'
         )
         setArticles(resp.data)
       } catch {


### PR DESCRIPTION
## Summary
- revert English site API endpoints and config
- keep API proxy only in `frontend-pt`

## Testing
- `npm install` in `frontend-pt`
- `npm run lint` *(failed: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_685853ba9388832f948b25ec8c400843