### PR TITLE
Adjust mobile search and fix build

### DIFF
--- a/frontend-en/src/components/Navbar/Navbar.tsx
+++ b/frontend-en/src/components/Navbar/Navbar.tsx
@@ -88,7 +88,7 @@ export default function Navbar() {
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="Search..."
-                className="px-2 py-1 focus:outline-none"
+                className="px-2 py-1 focus:outline-none w-28 sm:w-36"
               />
               <button
                 type="submit"
@@ -136,6 +136,7 @@ export default function Navbar() {
 
         {/* Dropdowns */}
         {isLoginOpen && <LoginDropdown onClose={() => setIsLoginOpen(false)} />}
+        </div>
       </nav>
 
       {/* Spacer para evitar overlap */}

--- a/frontend-pt/src/components/Navbar/Navbar.tsx
+++ b/frontend-pt/src/components/Navbar/Navbar.tsx
@@ -91,7 +91,7 @@ export default function Navbar() {
                 value={searchQuery}
                 onChange={e => setSearchQuery(e.target.value)}
                 placeholder="Pesquisar..."
-                className="px-2 py-1 focus:outline-none"
+                className="px-2 py-1 focus:outline-none w-28 sm:w-36"
               />
               <button
                 type="submit"


### PR DESCRIPTION
## Summary
- fix missing closing tag in frontend-en Navbar
- keep logo larger on small screens by reducing search input width
- apply same mobile width adjustment in Portuguese Navbar

## Testing
- `npm run build` in `frontend-en`
- `npm run build` in `frontend-pt`


------
https://chatgpt.com/codex/tasks/task_e_685866f20564832fafba10b2f565fd82