### PR TITLE
Remove link from excerpt in Airdrops page

### DIFF
--- a/frontend-en/src/pages/airdrops/index.tsx
+++ b/frontend-en/src/pages/airdrops/index.tsx
@@ -133,12 +133,16 @@ export default function AirdropsIndexPage() {
                     alt={article.title}
                     className="w-full h-64 object-cover rounded"
                   />
+                </a>
+              </Link>
+              <Link href={`/airdrops/${article.slug}`} legacyBehavior>
+                <a>
                   <h2 className="mt-4 text-2xl font-bold">
                     {article.title}
                   </h2>
-                  <p className="mt-2 text-lg">{article.excerpt}</p>
                 </a>
               </Link>
+              <p className="mt-2 text-lg">{article.excerpt}</p>
             </article>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- limit the clickable area of the English Airdrops page's two featured articles to only the image and title

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686059555ec0832f836ffd71bbd70ad2