### PR TITLE
Implement mobile toggle for side banners

### DIFF
--- a/frontend-en/src/components/SideBanners.tsx
+++ b/frontend-en/src/components/SideBanners.tsx
@@ -7,6 +7,7 @@ export default function SideBanners() {
   const { user } = useAuth();
   const { subscribe, isSubscribed, loading, error, success } = useNewsletter();
   const [email, setEmail] = useState(user?.email ?? '');
+  const [open, setOpen] = useState(false);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -16,7 +17,16 @@ export default function SideBanners() {
   };
 
   return (
-    <aside className="absolute top-1/3 -right-36 hover:right-0 md:-right-36 md:hover:right-0 lg:-right-36 lg:hover:right-0 flex flex-col space-y-6 z-40 transition-all">
+    <aside
+      className={`absolute top-1/3 ${open ? 'right-0 md:right-0' : '-right-36 md:-right-36 md:hover:right-0 lg:-right-36 lg:hover:right-0'} flex flex-col space-y-6 z-40 transition-all`}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="md:hidden absolute -left-6 top-1/2 -translate-y-1/2 bg-primary text-white rounded-l px-1"
+      >
+        {open ? '<' : '>'}
+      </button>
       {/* Banner Newsletter */}
       <div className="block w-40 p-4 bg-primary text-white rounded-l-lg shadow text-center">
         <h3 className="font-bold mb-1 text-center">Newsletter</h3>


### PR DESCRIPTION
## Summary
- allow side banners to open/close on touch devices
- keep hover behaviour for larger screens

## Testing
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_68605ad64464832f988c2cac53053d63