### PR TITLE
Update side banner interaction

### DIFF
--- a/frontend-en/src/components/SideBanners.tsx
+++ b/frontend-en/src/components/SideBanners.tsx
@@ -18,15 +18,12 @@ export default function SideBanners() {
 
   return (
     <aside
-      className={`absolute top-1/3 ${open ? 'right-0 md:right-0' : '-right-36 md:-right-36 md:hover:right-0 lg:-right-36 lg:hover:right-0'} flex flex-col space-y-6 z-40 transition-all`}
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onTouchStart={() => setOpen(true)}
+      onTouchEnd={() => setOpen(false)}
+      className={`absolute top-1/3 ${open ? 'right-0' : '-right-36'} flex flex-col space-y-6 z-40 transition-all`}
     >
-      <button
-        type="button"
-        onClick={() => setOpen(!open)}
-        className="md:hidden absolute -left-6 top-1/2 -translate-y-1/2 bg-primary text-white rounded-l px-1"
-      >
-        {open ? '<' : '>'}
-      </button>
       {/* Banner Newsletter */}
       <div className="block w-40 p-4 bg-primary text-white rounded-l-lg shadow text-center">
         <h3 className="font-bold mb-1 text-center">Newsletter</h3>


### PR DESCRIPTION
## Summary
- remove the button from `SideBanners`
- open/close banner via mouse hover or touch events

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605e8e5658832f97d34c81f6d5db8f