### PR TITLE
Fix hero image size on Airdrops page

### DIFF
--- a/frontend-en/src/pages/airdrops/index.tsx
+++ b/frontend-en/src/pages/airdrops/index.tsx
@@ -101,7 +101,7 @@ export default function AirdropsIndexPage() {
               <img
                 src={special.imageUrl}
                 alt={special.title}
-                className="w-full h-auto object-cover rounded"
+                className="w-full h-56 md:h-64 lg:h-72 object-cover rounded"
               />
             </a>
           </Link>


### PR DESCRIPTION
## Summary
- shrink the hero image height on the Airdrops page for better layout on medium and large screens

## Testing
- `npx prettier -w frontend-en/src/pages/airdrops/index.tsx` *(fails: no)*

------
https://chatgpt.com/codex/tasks/task_e_686066c1cd2c832fb738d66ce1e40179