### PR TITLE
Fix side banners behavior

### DIFF
--- a/frontend-en/src/components/SideBanners.tsx
+++ b/frontend-en/src/components/SideBanners.tsx
@@ -22,7 +22,7 @@ export default function SideBanners() {
       onMouseLeave={() => setOpen(false)}
       onTouchStart={() => setOpen(true)}
       onTouchEnd={() => setOpen(false)}
-      className={`absolute top-1/3 ${open ? 'right-0' : '-right-36'} flex flex-col space-y-6 z-40 transition-all`}
+      className={`hidden md:flex absolute top-1/3 ${open ? 'right-0' : '-right-36'} flex-col space-y-6 z-40 transition-all`}
     >
       {/* Banner Newsletter */}
       <div className="block w-40 p-4 bg-primary text-white rounded-l-lg shadow text-center">


### PR DESCRIPTION
## Summary
- hide side banners on small screens so they only appear from medium width upwards

## Testing
- `npm install` in `frontend-en`
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_6860f3367a78832fbe56e368d0af20b5