### PR TITLE
Justify Airdrops page text

### DIFF
--- a/frontend-en/src/pages/airdrops/index.tsx
+++ b/frontend-en/src/pages/airdrops/index.tsx
@@ -113,7 +113,7 @@ export default function AirdropsIndexPage() {
                 </h2>
               </a>
             </Link>
-            <p className="mt-4 text-base">{specialText}</p>
+            <p className="mt-4 text-base text-justify">{specialText}</p>
             <Link href={`/airdrops/${special.slug}`} legacyBehavior>
               <a className="mt-4 inline-block text-blue-600 hover:underline">
                 Read more
@@ -142,7 +142,7 @@ export default function AirdropsIndexPage() {
                   </h2>
                 </a>
               </Link>
-              <p className="mt-2 text-lg">{article.excerpt}</p>
+              <p className="mt-2 text-lg text-justify">{article.excerpt}</p>
             </article>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- justify the main paragraph text on English Airdrops index page

## Testing
- `npm run lint` *(fails: prompts for interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_6860f5fd8030832f9ba6f147e5743e6e