### PR TITLE
Align pages with airdrops layout

### DIFF
--- a/frontend-en/src/pages/bitcoin/index.tsx
+++ b/frontend-en/src/pages/bitcoin/index.tsx
@@ -93,19 +93,25 @@ export default function BitcoinIndexPage() {
       </Head>
       <main className="max-w-7xl mx-auto px-4 py-8">
         {/* Special Top Story */}
-        <section className="mb-12 flex flex-col lg:flex-row items-start gap-6">
-          <img
-            src={special.imageUrl}
-            alt={special.title}
-            className="w-full lg:w-1/2 h-auto object-cover rounded"
-          />
+        <section className="mb-12 flex flex-col items-center text-center lg:flex-row lg:items-start lg:text-left gap-6">
+          <Link href={`/bitcoin/${special.slug}`} legacyBehavior>
+            <a className="block lg:w-1/2">
+              <img
+                src={special.imageUrl}
+                alt={special.title}
+                className="w-full h-56 md:h-64 lg:h-72 object-cover rounded"
+              />
+            </a>
+          </Link>
           <div className="lg:w-1/2">
-            <h2 className="text-2xl font-bold">{special.title}</h2>
-            <p className="mt-4 text-base">{specialText}</p>
             <Link href={`/bitcoin/${special.slug}`} legacyBehavior>
-              <a className="mt-4 inline-block text-blue-600 hover:underline">
-                Read more
+              <a>
+                <h2 className="text-2xl font-bold hover:underline">{special.title}</h2>
               </a>
+            </Link>
+            <p className="mt-4 text-base text-justify">{specialText}</p>
+            <Link href={`/bitcoin/${special.slug}`} legacyBehavior>
+              <a className="mt-4 inline-block text-blue-600 hover:underline">Read more</a>
             </Link>
           </div>
         </section>
@@ -121,12 +127,14 @@ export default function BitcoinIndexPage() {
                     alt={article.title}
                     className="w-full h-64 object-cover rounded"
                   />
-                  <h2 className="mt-4 text-2xl font-bold">
-                    {article.title}
-                  </h2>
-                  <p className="mt-2 text-lg">{article.excerpt}</p>
                 </a>
               </Link>
+              <Link href={`/bitcoin/${article.slug}`} legacyBehavior>
+                <a>
+                  <h2 className="mt-4 text-2xl font-bold">{article.title}</h2>
+                </a>
+              </Link>
+              <p className="mt-2 text-lg text-justify">{article.excerpt}</p>
             </article>
           ))}
         </div>

--- a/frontend-en/src/pages/contact.tsx
+++ b/frontend-en/src/pages/contact.tsx
@@ -57,7 +57,7 @@ export default function ContactPage() {
           </div>
           <button
             type="submit"
-            className="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            className="px-6 py-2 bg-primary text-white rounded hover:bg-primary-dark"
           >
             Send Message
           </button>

--- a/frontend-en/src/pages/guides/index.tsx
+++ b/frontend-en/src/pages/guides/index.tsx
@@ -93,19 +93,25 @@ export default function GuidesIndexPage() {
       </Head>
       <main className="max-w-7xl mx-auto px-4 py-8">
         {/* Special Top Story */}
-        <section className="mb-12 flex flex-col lg:flex-row items-start gap-6">
-          <img
-            src={special.imageUrl}
-            alt={special.title}
-            className="w-full lg:w-1/2 h-auto object-cover rounded"
-          />
+        <section className="mb-12 flex flex-col items-center text-center lg:flex-row lg:items-start lg:text-left gap-6">
+          <Link href={`/guides/${special.slug}`} legacyBehavior>
+            <a className="block lg:w-1/2">
+              <img
+                src={special.imageUrl}
+                alt={special.title}
+                className="w-full h-56 md:h-64 lg:h-72 object-cover rounded"
+              />
+            </a>
+          </Link>
           <div className="lg:w-1/2">
-            <h2 className="text-2xl font-bold">{special.title}</h2>
-            <p className="mt-4 text-base">{specialText}</p>
             <Link href={`/guides/${special.slug}`} legacyBehavior>
-              <a className="mt-4 inline-block text-blue-600 hover:underline">
-                Read more
+              <a>
+                <h2 className="text-2xl font-bold hover:underline">{special.title}</h2>
               </a>
+            </Link>
+            <p className="mt-4 text-base text-justify">{specialText}</p>
+            <Link href={`/guides/${special.slug}`} legacyBehavior>
+              <a className="mt-4 inline-block text-blue-600 hover:underline">Read more</a>
             </Link>
           </div>
         </section>
@@ -121,12 +127,14 @@ export default function GuidesIndexPage() {
                     alt={article.title}
                     className="w-full h-64 object-cover rounded"
                   />
-                  <h2 className="mt-4 text-2xl font-bold">
-                    {article.title}
-                  </h2>
-                  <p className="mt-2 text-lg">{article.excerpt}</p>
                 </a>
               </Link>
+              <Link href={`/guides/${article.slug}`} legacyBehavior>
+                <a>
+                  <h2 className="mt-4 text-2xl font-bold">{article.title}</h2>
+                </a>
+              </Link>
+              <p className="mt-2 text-lg text-justify">{article.excerpt}</p>
             </article>
           ))}
         </div>

--- a/frontend-en/src/pages/presale/index.tsx
+++ b/frontend-en/src/pages/presale/index.tsx
@@ -93,19 +93,25 @@ export default function PresaleIndexPage() {
       </Head>
       <main className="max-w-7xl mx-auto px-4 py-8">
         {/* Special Top Story */}
-        <section className="mb-12 flex flex-col lg:flex-row items-start gap-6">
-          <img
-            src={special.imageUrl}
-            alt={special.title}
-            className="w-full lg:w-1/2 h-auto object-cover rounded"
-          />
+        <section className="mb-12 flex flex-col items-center text-center lg:flex-row lg:items-start lg:text-left gap-6">
+          <Link href={`/presale/${special.slug}`} legacyBehavior>
+            <a className="block lg:w-1/2">
+              <img
+                src={special.imageUrl}
+                alt={special.title}
+                className="w-full h-56 md:h-64 lg:h-72 object-cover rounded"
+              />
+            </a>
+          </Link>
           <div className="lg:w-1/2">
-            <h2 className="text-2xl font-bold">{special.title}</h2>
-            <p className="mt-4 text-base">{specialText}</p>
             <Link href={`/presale/${special.slug}`} legacyBehavior>
-              <a className="mt-4 inline-block text-blue-600 hover:underline">
-                Read more
+              <a>
+                <h2 className="text-2xl font-bold hover:underline">{special.title}</h2>
               </a>
+            </Link>
+            <p className="mt-4 text-base text-justify">{specialText}</p>
+            <Link href={`/presale/${special.slug}`} legacyBehavior>
+              <a className="mt-4 inline-block text-blue-600 hover:underline">Read more</a>
             </Link>
           </div>
         </section>
@@ -121,10 +127,14 @@ export default function PresaleIndexPage() {
                     alt={article.title}
                     className="w-full h-64 object-cover rounded"
                   />
-                  <h2 className="mt-4 text-2xl font-bold">{article.title}</h2>
-                  <p className="mt-2 text-lg">{article.excerpt}</p>
                 </a>
               </Link>
+              <Link href={`/presale/${article.slug}`} legacyBehavior>
+                <a>
+                  <h2 className="mt-4 text-2xl font-bold">{article.title}</h2>
+                </a>
+              </Link>
+              <p className="mt-2 text-lg text-justify">{article.excerpt}</p>
             </article>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- match layout for Guides, Bitcoin and Pre‑sale pages to Airdrops design
- update contact page button color

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_6860f7d5ba24832f8e16bb51ca0a64f0