### PR TITLE
Fix category link slugs

### DIFF
--- a/frontend-en/src/pages/Africa/index.tsx
+++ b/frontend-en/src/pages/Africa/index.tsx
@@ -1,4 +1,4 @@
-// src/pages/africa/index.tsx
+// src/pages/Africa/index.tsx
 import Head from 'next/head'
 import Link from 'next/link'
 import { Article } from '../../types'
@@ -106,7 +106,7 @@ export default function AfricaIndexPage() {
       <main className="max-w-7xl mx-auto px-4 py-8">
         {/* Special Top Story */}
         <section className="mb-12 flex flex-col items-center text-center lg:flex-row lg:items-start gap-6">
-          <Link href={`/africa/${special.slug}`} legacyBehavior>
+          <Link href={`/Africa/${special.slug}`} legacyBehavior>
             <a className="block lg:w-1/2">
               <img
                 src={special.imageUrl}
@@ -116,7 +116,7 @@ export default function AfricaIndexPage() {
             </a>
           </Link>
           <div className="lg:w-1/2">
-            <Link href={`/africa/${special.slug}`} legacyBehavior>
+            <Link href={`/Africa/${special.slug}`} legacyBehavior>
               <a>
                 <h2 className="text-2xl font-bold hover:underline">
                   {special.title}
@@ -124,7 +124,7 @@ export default function AfricaIndexPage() {
               </a>
             </Link>
             <p className="mt-4 text-base text-justify">{specialText}</p>
-            <Link href={`/africa/${special.slug}`} legacyBehavior>
+            <Link href={`/Africa/${special.slug}`} legacyBehavior>
               <a className="mt-4 inline-block text-blue-600 hover:underline">
                 Read more
               </a>
@@ -136,7 +136,7 @@ export default function AfricaIndexPage() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">
           {[feature1, feature2].map((article) => (
             <article key={article.slug}>
-              <Link href={`/africa/${article.slug}`} legacyBehavior>
+              <Link href={`/Africa/${article.slug}`} legacyBehavior>
                 <a className="block">
                   <img
                     src={article.imageUrl}
@@ -145,7 +145,7 @@ export default function AfricaIndexPage() {
                   />
                 </a>
               </Link>
-              <Link href={`/africa/${article.slug}`} legacyBehavior>
+              <Link href={`/Africa/${article.slug}`} legacyBehavior>
                 <a>
                   <h2 className="mt-4 text-2xl font-bold">
                     {article.title}
@@ -161,7 +161,7 @@ export default function AfricaIndexPage() {
         <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {rest.map((article) => (
             <article key={article.slug}>
-              <Link href={`/africa/${article.slug}`} legacyBehavior>
+              <Link href={`/Africa/${article.slug}`} legacyBehavior>
                 <a className="block relative h-48 overflow-hidden rounded">
                   <img
                     src={article.imageUrl}

--- a/frontend-en/src/pages/Australia/index.tsx
+++ b/frontend-en/src/pages/Australia/index.tsx
@@ -1,4 +1,4 @@
-// src/pages/australia/index.tsx
+// src/pages/Australia/index.tsx
 import Head from 'next/head'
 import Link from 'next/link'
 import { Article } from '../../types'
@@ -106,7 +106,7 @@ export default function AustraliaIndexPage() {
       <main className="max-w-7xl mx-auto px-4 py-8">
         {/* Special Top Story */}
         <section className="mb-12 flex flex-col items-center text-center lg:flex-row lg:items-start gap-6">
-          <Link href={`/australia/${special.slug}`} legacyBehavior>
+          <Link href={`/Australia/${special.slug}`} legacyBehavior>
             <a className="block lg:w-1/2">
               <img
                 src={special.imageUrl}
@@ -116,7 +116,7 @@ export default function AustraliaIndexPage() {
             </a>
           </Link>
           <div className="lg:w-1/2">
-            <Link href={`/australia/${special.slug}`} legacyBehavior>
+            <Link href={`/Australia/${special.slug}`} legacyBehavior>
               <a>
                 <h2 className="text-2xl font-bold hover:underline">
                   {special.title}
@@ -124,7 +124,7 @@ export default function AustraliaIndexPage() {
               </a>
             </Link>
             <p className="mt-4 text-base text-justify">{specialText}</p>
-            <Link href={`/australia/${special.slug}`} legacyBehavior>
+            <Link href={`/Australia/${special.slug}`} legacyBehavior>
               <a className="mt-4 inline-block text-blue-600 hover:underline">
                 Read more
               </a>
@@ -136,7 +136,7 @@ export default function AustraliaIndexPage() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">
           {[feature1, feature2].map((article) => (
             <article key={article.slug}>
-              <Link href={`/australia/${article.slug}`} legacyBehavior>
+              <Link href={`/Australia/${article.slug}`} legacyBehavior>
                 <a className="block">
                   <img
                     src={article.imageUrl}
@@ -145,7 +145,7 @@ export default function AustraliaIndexPage() {
                   />
                 </a>
               </Link>
-              <Link href={`/australia/${article.slug}`} legacyBehavior>
+              <Link href={`/Australia/${article.slug}`} legacyBehavior>
                 <a>
                   <h2 className="mt-4 text-2xl font-bold">
                     {article.title}
@@ -161,7 +161,7 @@ export default function AustraliaIndexPage() {
         <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {rest.map((article) => (
             <article key={article.slug}>
-              <Link href={`/australia/${article.slug}`} legacyBehavior>
+              <Link href={`/Australia/${article.slug}`} legacyBehavior>
                 <a className="block relative h-48 overflow-hidden rounded">
                   <img
                     src={article.imageUrl}

--- a/frontend-en/src/pages/Canada/index.tsx
+++ b/frontend-en/src/pages/Canada/index.tsx
@@ -1,4 +1,4 @@
-// src/pages/canada/index.tsx
+// src/pages/Canada/index.tsx
 import Head from 'next/head'
 import Link from 'next/link'
 import { Article } from '../../types'
@@ -106,7 +106,7 @@ export default function CanadaIndexPage() {
       <main className="max-w-7xl mx-auto px-4 py-8">
         {/* Special Top Story */}
         <section className="mb-12 flex flex-col items-center text-center lg:flex-row lg:items-start gap-6">
-          <Link href={`/canada/${special.slug}`} legacyBehavior>
+          <Link href={`/Canada/${special.slug}`} legacyBehavior>
             <a className="block lg:w-1/2">
               <img
                 src={special.imageUrl}
@@ -116,7 +116,7 @@ export default function CanadaIndexPage() {
             </a>
           </Link>
           <div className="lg:w-1/2">
-            <Link href={`/canada/${special.slug}`} legacyBehavior>
+            <Link href={`/Canada/${special.slug}`} legacyBehavior>
               <a>
                 <h2 className="text-2xl font-bold hover:underline">
                   {special.title}
@@ -124,7 +124,7 @@ export default function CanadaIndexPage() {
               </a>
             </Link>
             <p className="mt-4 text-base text-justify">{specialText}</p>
-            <Link href={`/canada/${special.slug}`} legacyBehavior>
+            <Link href={`/Canada/${special.slug}`} legacyBehavior>
               <a className="mt-4 inline-block text-blue-600 hover:underline">
                 Read more
               </a>
@@ -136,7 +136,7 @@ export default function CanadaIndexPage() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">
           {[feature1, feature2].map((article) => (
             <article key={article.slug}>
-              <Link href={`/canada/${article.slug}`} legacyBehavior>
+              <Link href={`/Canada/${article.slug}`} legacyBehavior>
                 <a className="block">
                   <img
                     src={article.imageUrl}
@@ -145,7 +145,7 @@ export default function CanadaIndexPage() {
                   />
                 </a>
               </Link>
-              <Link href={`/canada/${article.slug}`} legacyBehavior>
+              <Link href={`/Canada/${article.slug}`} legacyBehavior>
                 <a>
                   <h2 className="mt-4 text-2xl font-bold">
                     {article.title}
@@ -161,7 +161,7 @@ export default function CanadaIndexPage() {
         <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {rest.map((article) => (
             <article key={article.slug}>
-              <Link href={`/canada/${article.slug}`} legacyBehavior>
+              <Link href={`/Canada/${article.slug}`} legacyBehavior>
                 <a className="block relative h-48 overflow-hidden rounded">
                   <img
                     src={article.imageUrl}

--- a/frontend-en/src/pages/Europe/index.tsx
+++ b/frontend-en/src/pages/Europe/index.tsx
@@ -1,4 +1,4 @@
-// src/pages/europe/index.tsx
+// src/pages/Europe/index.tsx
 import Head from 'next/head'
 import Link from 'next/link'
 import { Article } from '../../types'
@@ -107,7 +107,7 @@ export default function EuropeIndexPage() {
       <main className="max-w-7xl mx-auto px-4 py-8">
         {/* Special Top Story */}
         <section className="mb-12 flex flex-col items-center text-center lg:flex-row lg:items-start gap-6">
-          <Link href={`/europe/${special.slug}`} legacyBehavior>
+          <Link href={`/Europe/${special.slug}`} legacyBehavior>
             <a className="block lg:w-1/2">
               <img
                 src={special.imageUrl}
@@ -117,7 +117,7 @@ export default function EuropeIndexPage() {
             </a>
           </Link>
           <div className="lg:w-1/2">
-            <Link href={`/europe/${special.slug}`} legacyBehavior>
+            <Link href={`/Europe/${special.slug}`} legacyBehavior>
               <a>
                 <h2 className="text-2xl font-bold hover:underline">
                   {special.title}
@@ -125,7 +125,7 @@ export default function EuropeIndexPage() {
               </a>
             </Link>
             <p className="mt-4 text-base text-justify">{specialText}</p>
-            <Link href={`/europe/${special.slug}`} legacyBehavior>
+            <Link href={`/Europe/${special.slug}`} legacyBehavior>
               <a className="mt-4 inline-block text-blue-600 hover:underline">
                 Read more
               </a>
@@ -137,7 +137,7 @@ export default function EuropeIndexPage() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">
           {[feature1, feature2].map((article) => (
             <article key={article.slug}>
-              <Link href={`/europe/${article.slug}`} legacyBehavior>
+              <Link href={`/Europe/${article.slug}`} legacyBehavior>
                 <a className="block">
                   <img
                     src={article.imageUrl}
@@ -146,7 +146,7 @@ export default function EuropeIndexPage() {
                   />
                 </a>
               </Link>
-              <Link href={`/europe/${article.slug}`} legacyBehavior>
+              <Link href={`/Europe/${article.slug}`} legacyBehavior>
                 <a>
                   <h2 className="mt-4 text-2xl font-bold">
                     {article.title}
@@ -162,7 +162,7 @@ export default function EuropeIndexPage() {
         <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {rest.map((article) => (
             <article key={article.slug}>
-              <Link href={`/europe/${article.slug}`} legacyBehavior>
+              <Link href={`/Europe/${article.slug}`} legacyBehavior>
                 <a className="block relative h-48 overflow-hidden rounded">
                   <img
                     src={article.imageUrl}

--- a/frontend-en/src/pages/Global/index.tsx
+++ b/frontend-en/src/pages/Global/index.tsx
@@ -1,4 +1,4 @@
-// src/pages/global/index.tsx
+// src/pages/Global/index.tsx
 import Head from 'next/head'
 import Link from 'next/link'
 import { Article } from '../../types'
@@ -107,7 +107,7 @@ export default function GlobalIndexPage() {
       <main className="max-w-7xl mx-auto px-4 py-8">
         {/* Special Top Story */}
         <section className="mb-12 flex flex-col items-center text-center lg:flex-row lg:items-start gap-6">
-          <Link href={`/global/${special.slug}`} legacyBehavior>
+          <Link href={`/Global/${special.slug}`} legacyBehavior>
             <a className="block lg:w-1/2">
               <img
                 src={special.imageUrl}
@@ -117,7 +117,7 @@ export default function GlobalIndexPage() {
             </a>
           </Link>
           <div className="lg:w-1/2">
-            <Link href={`/global/${special.slug}`} legacyBehavior>
+            <Link href={`/Global/${special.slug}`} legacyBehavior>
               <a>
                 <h2 className="text-2xl font-bold hover:underline">
                   {special.title}
@@ -125,7 +125,7 @@ export default function GlobalIndexPage() {
               </a>
             </Link>
             <p className="mt-4 text-base text-justify">{specialText}</p>
-            <Link href={`/global/${special.slug}`} legacyBehavior>
+            <Link href={`/Global/${special.slug}`} legacyBehavior>
               <a className="mt-4 inline-block text-blue-600 hover:underline">
                 Read more
               </a>
@@ -137,7 +137,7 @@ export default function GlobalIndexPage() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">
           {[feature1, feature2].map((article) => (
             <article key={article.slug}>
-              <Link href={`/global/${article.slug}`} legacyBehavior>
+              <Link href={`/Global/${article.slug}`} legacyBehavior>
                 <a className="block">
                   <img
                     src={article.imageUrl}
@@ -146,7 +146,7 @@ export default function GlobalIndexPage() {
                   />
                 </a>
               </Link>
-              <Link href={`/global/${article.slug}`} legacyBehavior>
+              <Link href={`/Global/${article.slug}`} legacyBehavior>
                 <a>
                   <h2 className="mt-4 text-2xl font-bold">
                     {article.title}
@@ -162,7 +162,7 @@ export default function GlobalIndexPage() {
         <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {rest.map((article) => (
             <article key={article.slug}>
-              <Link href={`/global/${article.slug}`} legacyBehavior>
+              <Link href={`/Global/${article.slug}`} legacyBehavior>
                 <a className="block relative h-48 overflow-hidden rounded">
                   <img
                     src={article.imageUrl}

--- a/frontend-en/src/pages/Ireland/index.tsx
+++ b/frontend-en/src/pages/Ireland/index.tsx
@@ -1,4 +1,4 @@
-// src/pages/ireland/index.tsx
+// src/pages/Ireland/index.tsx
 import Head from 'next/head'
 import Link from 'next/link'
 import { Article } from '../../types'
@@ -107,7 +107,7 @@ export default function IrelandIndexPage() {
       <main className="max-w-7xl mx-auto px-4 py-8">
         {/* Special Top Story */}
         <section className="mb-12 flex flex-col items-center text-center lg:flex-row lg:items-start gap-6">
-          <Link href={`/ireland/${special.slug}`} legacyBehavior>
+          <Link href={`/Ireland/${special.slug}`} legacyBehavior>
             <a className="block lg:w-1/2">
               <img
                 src={special.imageUrl}
@@ -117,7 +117,7 @@ export default function IrelandIndexPage() {
             </a>
           </Link>
           <div className="lg:w-1/2">
-            <Link href={`/ireland/${special.slug}`} legacyBehavior>
+            <Link href={`/Ireland/${special.slug}`} legacyBehavior>
               <a>
                 <h2 className="text-2xl font-bold hover:underline">
                   {special.title}
@@ -125,7 +125,7 @@ export default function IrelandIndexPage() {
               </a>
             </Link>
             <p className="mt-4 text-base text-justify">{specialText}</p>
-            <Link href={`/ireland/${special.slug}`} legacyBehavior>
+            <Link href={`/Ireland/${special.slug}`} legacyBehavior>
               <a className="mt-4 inline-block text-blue-600 hover:underline">
                 Read more
               </a>
@@ -137,7 +137,7 @@ export default function IrelandIndexPage() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">
           {[feature1, feature2].map((article) => (
             <article key={article.slug}>
-              <Link href={`/ireland/${article.slug}`} legacyBehavior>
+              <Link href={`/Ireland/${article.slug}`} legacyBehavior>
                 <a className="block">
                   <img
                     src={article.imageUrl}
@@ -146,7 +146,7 @@ export default function IrelandIndexPage() {
                   />
                 </a>
               </Link>
-              <Link href={`/ireland/${article.slug}`} legacyBehavior>
+              <Link href={`/Ireland/${article.slug}`} legacyBehavior>
                 <a>
                   <h2 className="mt-4 text-2xl font-bold">
                     {article.title}
@@ -162,7 +162,7 @@ export default function IrelandIndexPage() {
         <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {rest.map((article) => (
             <article key={article.slug}>
-              <Link href={`/ireland/${article.slug}`} legacyBehavior>
+              <Link href={`/Ireland/${article.slug}`} legacyBehavior>
                 <a className="block relative h-48 overflow-hidden rounded">
                   <img
                     src={article.imageUrl}

--- a/frontend-en/src/pages/New Zealand/index.tsx
+++ b/frontend-en/src/pages/New Zealand/index.tsx
@@ -1,4 +1,4 @@
-// src/pages/new-zealand/index.tsx
+// src/pages/New Zealand/index.tsx
 import Head from 'next/head'
 import Link from 'next/link'
 import { Article } from '../../types'
@@ -106,7 +106,7 @@ export default function NewZealandIndexPage() {
       <main className="max-w-7xl mx-auto px-4 py-8">
         {/* Special Top Story */}
         <section className="mb-12 flex flex-col items-center text-center lg:flex-row lg:items-start gap-6">
-          <Link href={`/new-zealand/${special.slug}`} legacyBehavior>
+          <Link href={`/New%20Zealand/${special.slug}`} legacyBehavior>
             <a className="block lg:w-1/2">
               <img
                 src={special.imageUrl}
@@ -116,7 +116,7 @@ export default function NewZealandIndexPage() {
             </a>
           </Link>
           <div className="lg:w-1/2">
-            <Link href={`/new-zealand/${special.slug}`} legacyBehavior>
+            <Link href={`/New%20Zealand/${special.slug}`} legacyBehavior>
               <a>
                 <h2 className="text-2xl font-bold hover:underline">
                   {special.title}
@@ -124,7 +124,7 @@ export default function NewZealandIndexPage() {
               </a>
             </Link>
             <p className="mt-4 text-base text-justify">{specialText}</p>
-            <Link href={`/new-zealand/${special.slug}`} legacyBehavior>
+            <Link href={`/New%20Zealand/${special.slug}`} legacyBehavior>
               <a className="mt-4 inline-block text-blue-600 hover:underline">
                 Read more
               </a>
@@ -136,7 +136,7 @@ export default function NewZealandIndexPage() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">
           {[feature1, feature2].map((article) => (
             <article key={article.slug}>
-              <Link href={`/new-zealand/${article.slug}`} legacyBehavior>
+              <Link href={`/New%20Zealand/${article.slug}`} legacyBehavior>
                 <a className="block">
                   <img
                     src={article.imageUrl}
@@ -145,7 +145,7 @@ export default function NewZealandIndexPage() {
                   />
                 </a>
               </Link>
-              <Link href={`/new-zealand/${article.slug}`} legacyBehavior>
+              <Link href={`/New%20Zealand/${article.slug}`} legacyBehavior>
                 <a>
                   <h2 className="mt-4 text-2xl font-bold">
                     {article.title}
@@ -161,7 +161,7 @@ export default function NewZealandIndexPage() {
         <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {rest.map((article) => (
             <article key={article.slug}>
-              <Link href={`/new-zealand/${article.slug}`} legacyBehavior>
+              <Link href={`/New%20Zealand/${article.slug}`} legacyBehavior>
                 <a className="block relative h-48 overflow-hidden rounded">
                   <img
                     src={article.imageUrl}

--- a/frontend-en/src/pages/USA/index.tsx
+++ b/frontend-en/src/pages/USA/index.tsx
@@ -1,4 +1,4 @@
-// src/pages/usa/index.tsx
+// src/pages/USA/index.tsx
 import Head from 'next/head'
 import Link from 'next/link'
 import { Article } from '../../types'
@@ -100,7 +100,7 @@ export default function USAIndexPage() {
       </Head>
       <main className="max-w-7xl mx-auto px-4 py-8">
         <section className="mb-12 flex flex-col items-center text-center lg:flex-row lg:items-start gap-6">
-          <Link href={`/usa/${special.slug}`} legacyBehavior>
+          <Link href={`/USA/${special.slug}`} legacyBehavior>
             <a className="block lg:w-1/2">
               <img
                 src={special.imageUrl}
@@ -110,7 +110,7 @@ export default function USAIndexPage() {
             </a>
           </Link>
           <div className="lg:w-1/2">
-            <Link href={`/usa/${special.slug}`} legacyBehavior>
+            <Link href={`/USA/${special.slug}`} legacyBehavior>
               <a>
                 <h2 className="text-2xl font-bold hover:underline">
                   {special.title}
@@ -118,7 +118,7 @@ export default function USAIndexPage() {
               </a>
             </Link>
             <p className="mt-4 text-base text-justify">{specialText}</p>
-            <Link href={`/usa/${special.slug}`} legacyBehavior>
+            <Link href={`/USA/${special.slug}`} legacyBehavior>
               <a className="mt-4 inline-block text-blue-600 hover:underline">
                 Read more
               </a>
@@ -129,7 +129,7 @@ export default function USAIndexPage() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-12">
           {[feature1, feature2].map((article) => (
             <article key={article.slug}>
-              <Link href={`/usa/${article.slug}`} legacyBehavior>
+              <Link href={`/USA/${article.slug}`} legacyBehavior>
                 <a className="block">
                   <img
                     src={article.imageUrl}
@@ -138,7 +138,7 @@ export default function USAIndexPage() {
                   />
                 </a>
               </Link>
-              <Link href={`/usa/${article.slug}`} legacyBehavior>
+              <Link href={`/USA/${article.slug}`} legacyBehavior>
                 <a>
                   <h2 className="mt-4 text-2xl font-bold">
                     {article.title}
@@ -153,7 +153,7 @@ export default function USAIndexPage() {
         <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {rest.map((article) => (
             <article key={article.slug}>
-              <Link href={`/usa/${article.slug}`} legacyBehavior>
+              <Link href={`/USA/${article.slug}`} legacyBehavior>
                 <a className="block relative h-48 overflow-hidden rounded">
                   <img
                     src={article.imageUrl}

--- a/frontend-en/src/pages/index.tsx
+++ b/frontend-en/src/pages/index.tsx
@@ -15,7 +15,7 @@ const regions = [
   { label: 'USA', folder: 'USA' },
   { label: 'Global', folder: 'Global' },
   { label: 'Canada', folder: 'Canada' },
-  { label: 'New Zealand', folder: 'New-Zealand' },
+  { label: 'New Zealand', folder: 'New%20Zealand' },
   { label: 'Africa', folder: 'Africa' },
   { label: 'Ireland', folder: 'Ireland' },
   { label: 'Australia', folder: 'Australia' },
@@ -123,7 +123,7 @@ const continentMap: Record<string, string> = {
   USA: 'North America',
   Canada: 'North America',
   Australia: 'Oceania',
-  'New-Zealand': 'Oceania',
+  'New%20Zealand': 'Oceania',
   Africa: 'Africa',
   Global: 'Global',
 }
@@ -220,7 +220,7 @@ export default function HomePage() {
           CA: 'Canada',
           IE: 'Ireland',
           AU: 'Australia',
-          NZ: 'New-Zealand',
+          NZ: 'New%20Zealand',
         }
         let primary = direct[code] ?? 'Global'
         const europeCodes = [


### PR DESCRIPTION
## Summary
- fix comment paths and link URLs to use correct capitalization across region pages
- update index page to reference `New%20Zealand`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861031e7a04832fbabc00f77a6580c6