### PR TITLE
Fix PT frontend ticker path

### DIFF
--- a/frontend-pt/src/components/CryptoTicker.tsx
+++ b/frontend-pt/src/components/CryptoTicker.tsx
@@ -13,7 +13,7 @@ export default function CryptoTicker() {
   useEffect(() => {
     async function fetchPrices() {
       try {
-        const resp = await apiClient.get<CryptoPrice[]>('/ticker')
+        const resp = await apiClient.get<CryptoPrice[]>('/api/crypto/ticker')
         setPrices(resp.data)
       } catch (err) {
         console.error('Falha ao carregar preços de cripto', err)

--- a/frontend-pt/src/contexts/CryptoContext.tsx
+++ b/frontend-pt/src/contexts/CryptoContext.tsx
@@ -29,7 +29,7 @@ export function CryptoProvider({ children }: { children: ReactNode }) {
       setLoading(true)
       setError(null)
       try {
-        const resp = await apiClient.get<CryptoPrice[]>('/ticker')
+        const resp = await apiClient.get<CryptoPrice[]>('/api/crypto/ticker')
         setPrices(resp.data)
       } catch (err: any) {
         console.error('Falha ao carregar preços de criptomoedas', err)


### PR DESCRIPTION
## Summary
- point Portuguese ticker requests to `/api/crypto/ticker`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686119dbe3ac832fba7eeb88e89aff29