### PR TITLE
Update PT frontend backend url

### DIFF
--- a/frontend-pt/.env.local
+++ b/frontend-pt/.env.local
@@ -1,2 +1,2 @@
 # URL do seu backend (usado em apiClient.ts)
-NEXT_PUBLIC_API_URL=http://naoseicripto.com/wp-json/jsbackend/v1
+NEXT_PUBLIC_API_URL=http://naoseicripto.com/wp-json/krm/v1

--- a/frontend-pt/README.md
+++ b/frontend-pt/README.md
@@ -26,7 +26,7 @@ cp .env.local .env.local  # edit to point to your backend
 Example `.env.local`:
 
 ```
-NEXT_PUBLIC_API_URL=https://naoseicripto.com/wp-json/jsbackend/v1
+NEXT_PUBLIC_API_URL=https://naoseicripto.com/wp-json/krm/v1
 ```
 
 ## Available scripts


### PR DESCRIPTION
## Summary
- update example API url in PT frontend README
- point `.env.local` at the new `krm` backend path

## Testing
- `npm run lint` *(fails: asks for eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_68612da90fc4832fb55c8b507b56d468