### PR TITLE
Fix API URL protocol for Portuguese frontend

### DIFF
--- a/frontend-pt/.env.local
+++ b/frontend-pt/.env.local
@@ -1,2 +1,2 @@
 # URL do seu backend (usado em apiClient.ts)
-NEXT_PUBLIC_API_URL=http://naoseicripto.com/wp-json/krm/v1
+NEXT_PUBLIC_API_URL=https://naoseicripto.com/wp-json/krm/v1


### PR DESCRIPTION
## Summary
- use HTTPS for API endpoint in `frontend-pt/.env.local`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68614815deb8832fa38d90dc469b7b3d