### PR TITLE
Fix crypto ticker on PT frontend

### DIFF
--- a/frontend-pt/.env.local
+++ b/frontend-pt/.env.local
@@ -1,2 +1,2 @@
 # URL do seu backend (usado em apiClient.ts)
-NEXT_PUBLIC_API_URL=https://naoseicripto.com/wp-json/krm/v1
+NEXT_PUBLIC_API_URL=https://krmcrypto.onrender.com/api

--- a/frontend-pt/README.md
+++ b/frontend-pt/README.md
@@ -26,7 +26,7 @@ cp .env.local .env.local  # edit to point to your backend
 Example `.env.local`:
 
 ```
-NEXT_PUBLIC_API_URL=https://naoseicripto.com/wp-json/krm/v1
+NEXT_PUBLIC_API_URL=https://krmcrypto.onrender.com/api
 ```
 
 ## Available scripts

--- a/frontend-pt/src/components/CryptoTicker.tsx
+++ b/frontend-pt/src/components/CryptoTicker.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import apiClient from '../utils/apiClient'
+
 
 interface CryptoPrice {
   symbol: string
@@ -13,8 +13,12 @@ export default function CryptoTicker() {
   useEffect(() => {
     async function fetchPrices() {
       try {
-        const resp = await apiClient.get<CryptoPrice[]>('/api/crypto/ticker')
-        setPrices(resp.data)
+        const resp = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL}/crypto/ticker`
+        )
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+        const data = (await resp.json()) as CryptoPrice[]
+        setPrices(data)
       } catch (err) {
         console.error('Falha ao carregar preços de cripto', err)
       }

--- a/frontend-pt/src/contexts/CryptoContext.tsx
+++ b/frontend-pt/src/contexts/CryptoContext.tsx
@@ -5,7 +5,6 @@ import {
   useEffect,
   useState,
 } from 'react'
-import apiClient from '../utils/apiClient'
 import { CryptoPrice } from '../types'
 
 interface CryptoContextType {
@@ -29,8 +28,12 @@ export function CryptoProvider({ children }: { children: ReactNode }) {
       setLoading(true)
       setError(null)
       try {
-        const resp = await apiClient.get<CryptoPrice[]>('/api/crypto/ticker')
-        setPrices(resp.data)
+        const resp = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL}/crypto/ticker`
+        )
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+        const data = (await resp.json()) as CryptoPrice[]
+        setPrices(data)
       } catch (err: any) {
         console.error('Falha ao carregar preços de criptomoedas', err)
         setError('Falha ao carregar preços de criptomoedas')


### PR DESCRIPTION
## Summary
- point `frontend-pt` API URL to the Node backend
- fetch ticker prices directly from the backend in `CryptoTicker` and `CryptoContext`
- update README example

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68614a919b00832faa4b2582fbb938ee