### PR TITLE
Fix geolocation path in pt frontend

### DIFF
--- a/frontend-pt/src/utils/geo.ts
+++ b/frontend-pt/src/utils/geo.ts
@@ -14,6 +14,6 @@ export interface GeoData {
  * Retorna pelo menos o nome ou código do país.
  */
 export async function fetchUserGeo(): Promise<GeoData> {
-  const resp = await apiClient.get<GeoData>('/geo')
+  const resp = await apiClient.get<GeoData>('/api/geo')
   return resp.data
 }


### PR DESCRIPTION
## Summary
- align PT geolocation request path with EN frontend

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686157b3f860832fbec59abbe2a030b5