### PR TITLE
Resolve slug build error

### DIFF
--- a/frontend-en/src/pages/USA/index.tsx
+++ b/frontend-en/src/pages/USA/index.tsx
@@ -1,7 +1,7 @@
 // src/pages/USA/index.tsx
 import Head from 'next/head'
 import Link from 'next/link'
-import { Article } from '../../types'
+import type { Article } from '../../types'
 
 const articles: Article[] = [
   {
@@ -82,7 +82,7 @@ const usaArticles: Article[] = [
   articles[3],
   articles[5],
   articles[6],
-]
+].filter(Boolean)
 
 const [feature1, feature2, special, ...rest] = usaArticles
 


### PR DESCRIPTION
## Summary
- avoid runtime import of types and filter undefined articles in USA index page

## Testing
- `npm run build` in `frontend-en`

------
https://chatgpt.com/codex/tasks/task_e_68618ef7da34832faf68919d46c82fbf